### PR TITLE
Implement UpdateVolume

### DIFF
--- a/data/volume.go
+++ b/data/volume.go
@@ -84,13 +84,85 @@ func AddVolume(c context.Context, volume *vo.VolumeVO) (*string, error) {
 }
 
 func UpdateVolume(c context.Context, id string, volume *vo.VolumeVO) (*vo.VolumeVO, error) {
+	logging.Logger.Info("UpdateVolume", "c", c, "id", id, "volume", volume)
+
 	_, span := otel.Tracer("volume").Start(c, "db-update-volume", oteltrace.WithAttributes(attribute.String("id", id)))
+	defer span.End()
 
-	// TODO
+	existing, err := GetVolume(c, id)
+	if err != nil {
+		logging.Logger.Error("Error while looking up existing Volume for update", "id", id, "error", err)
+		return nil, err
+	}
+	if existing == nil {
+		logging.Logger.Info(fmt.Sprintf("Volume not found for update, ID: %s", id))
+		return nil, nil
+	}
 
-	span.End()
+	properties := modelcoreutil.ToPropertyModels(volume.Properties)
+	tags := modelcoreutil.ToTagModels(volume.Tags)
+	systemIds := util.Map[vo.SystemVO, string](volume.Systems, func(system vo.SystemVO) *string {
+		return &system.ID
+	})
+	publisherIds := util.Map[vo.PublisherVO, string](volume.Publishers, func(publisher vo.PublisherVO) *string {
+		return &publisher.ID
+	})
+	studioIds := util.Map[vo.StudioVO, string](volume.Studios, func(studio vo.StudioVO) *string {
+		return &studio.ID
+	})
+	licenseIds := util.Map[vo.LicenseVO, string](volume.Licenses, func(license vo.LicenseVO) *string {
+		return &license.ID
+	})
 
-	return nil, nil
+	model := models.Volume{
+		ID:           id,
+		Title:        volume.Title,
+		Description:  volume.Description,
+		Notes:        volume.Notes,
+		Properties:   properties,
+		Tags:         tags,
+		SystemIds:    systemIds,
+		PublisherIds: publisherIds,
+		StudioIds:    studioIds,
+		LicenseIds:   licenseIds,
+		Auditable: modelcore.Auditable{
+			CreatedAt: existing.CreatedAt,
+			CreatedBy: existing.CreatedBy,
+			UpdatedAt: time.Now(),
+			UpdatedBy: volume.UpdatedBy,
+			DeletedAt: nil,
+			DeletedBy: nil,
+		},
+	}
+	logging.Logger.Debug("Volume model for update", "model", model)
+
+	data, err := bson.Marshal(model)
+	if err != nil {
+		logging.Logger.Error("Error while preparing Volume document for update", "error", err)
+		return nil, err
+	}
+	var update bson.D
+	if err := bson.Unmarshal(data, &update); err != nil {
+		logging.Logger.Error("Error while unmarshaling Volume document for update", "error", err)
+		return nil, err
+	}
+
+	result, err := database.Db.Collection("volumes").UpdateOne(
+		c,
+		bson.D{{Key: "_id", Value: id}},
+		bson.D{{Key: "$set", Value: update}},
+	)
+	logging.Logger.Debug("update result", "result", result, "err", err)
+	if err != nil {
+		logging.Logger.Error("Error while updating Volume in database", "id", id, "error", err)
+		return nil, err
+	}
+	if result.MatchedCount == 0 {
+		logging.Logger.Info(fmt.Sprintf("Volume not found for update, ID: %s", id))
+		return nil, nil
+	}
+
+	return GetVolume(c, id)
 }
 
 func DeleteVolume(c context.Context, id string) error {

--- a/data/volume_test.go
+++ b/data/volume_test.go
@@ -100,6 +100,43 @@ func (suite *VolumeDataTestSuite) TestQueryVolumesProjected() {
 	assert.NotEmpty(suite.T(), volumes)
 }
 
+func (suite *VolumeDataTestSuite) TestUpdateVolume() {
+	updated, err := UpdateVolume(suite.T().Context(), suite.seedVolumeID, &vo.VolumeVO{
+		Title:       "Updated Test Volume",
+		Description: "This volume was updated.",
+	})
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), updated)
+	assert.Equal(suite.T(), "Updated Test Volume", updated.Title)
+	assert.Equal(suite.T(), "This volume was updated.", updated.Description)
+
+	fetched, err := GetVolume(suite.T().Context(), suite.seedVolumeID)
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), fetched)
+	assert.Equal(suite.T(), "Updated Test Volume", fetched.Title)
+}
+
+func (suite *VolumeDataTestSuite) TestUpdateVolumePreservesCreatedAudit() {
+	before, err := GetVolume(suite.T().Context(), suite.seedVolumeID)
+	assert.NoError(suite.T(), err)
+
+	updated, err := UpdateVolume(suite.T().Context(), suite.seedVolumeID, &vo.VolumeVO{
+		Title: "Another Update",
+	})
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), updated)
+	assert.Equal(suite.T(), before.CreatedAt, updated.CreatedAt)
+	assert.True(suite.T(), updated.UpdatedAt.After(before.UpdatedAt) || updated.UpdatedAt.Equal(before.UpdatedAt))
+}
+
+func (suite *VolumeDataTestSuite) TestUpdateVolumeNotFound() {
+	updated, err := UpdateVolume(suite.T().Context(), "000000000000000000000000", &vo.VolumeVO{
+		Title: "Does Not Exist",
+	})
+	assert.NoError(suite.T(), err)
+	assert.Nil(suite.T(), updated)
+}
+
 func (suite *VolumeDataTestSuite) TestQueryVolumesPaged() {
 	params := apiutil.QueryParams{
 		Limit: 10,


### PR DESCRIPTION
Fills in the `UpdateVolume` TODO stub, needed by catalog-api's PATCH /volumes/:id endpoint.

Preserves CreatedAt/CreatedBy on update, sets UpdatedAt/UpdatedBy, and returns 404-equivalent
(nil, nil) when the volume doesn't exist. Uses a raw UpdateOne rather than mongodb.go's generic
Update[T] helper, since Volume's `_id` is stored as a plain hex string, not a BSON ObjectID -
Update[T] filters by primitive.ObjectID and would silently match nothing.

Refs sweetrpg/platform#35
OpenSpec change: `openspec/changes/volume-edit-with-approval-workflow/proposal.md` (in the
`platform` umbrella repo)