### PR TITLE
fix(volume): use pointer-slice relationship VOs after catalog-objects.go v0.0.197

### DIFF
--- a/data/volume.go
+++ b/data/volume.go
@@ -10,7 +10,6 @@ import (
 	"github.com/sweetrpg/catalog-objects.go/models"
 	"github.com/sweetrpg/catalog-objects.go/vo"
 	"github.com/sweetrpg/common.go/logging"
-	"github.com/sweetrpg/common.go/util"
 	modelcore "github.com/sweetrpg/model-core.go/models"
 	modelcoreutil "github.com/sweetrpg/model-core.go/util"
 	modelcorevo "github.com/sweetrpg/model-core.go/vo"
@@ -31,21 +30,13 @@ func AddVolume(c context.Context, volume *vo.VolumeVO) (*string, error) {
 	logging.Logger.Debug("ToPropertyModels", "properties", properties)
 	tags := modelcoreutil.ToTagModels(volume.Tags)
 	logging.Logger.Debug("ToTagModels", "tags", tags)
-	systemIds := util.Map[vo.SystemVO, string](volume.Systems, func(system vo.SystemVO) *string {
-		return &system.ID
-	})
+	systemIds := relationIDs(volume.Systems, func(s *vo.SystemVO) string { return s.ID })
 	logging.Logger.Debug("map systems", "systemIds", systemIds)
-	publisherIds := util.Map[vo.PublisherVO, string](volume.Publishers, func(publisher vo.PublisherVO) *string {
-		return &publisher.ID
-	})
+	publisherIds := relationIDs(volume.Publishers, func(p *vo.PublisherVO) string { return p.ID })
 	logging.Logger.Debug("map publishers", "publisherIds", publisherIds)
-	studioIds := util.Map[vo.StudioVO, string](volume.Studios, func(studio vo.StudioVO) *string {
-		return &studio.ID
-	})
+	studioIds := relationIDs(volume.Studios, func(s *vo.StudioVO) string { return s.ID })
 	logging.Logger.Debug("map studios", "studioIds", studioIds)
-	licenseIds := util.Map[vo.LicenseVO, string](volume.Licenses, func(license vo.LicenseVO) *string {
-		return &license.ID
-	})
+	licenseIds := relationIDs(volume.Licenses, func(l *vo.LicenseVO) string { return l.ID })
 	logging.Logger.Debug("map licenses", "licenseIds", licenseIds)
 
 	now := time.Now()
@@ -101,18 +92,10 @@ func UpdateVolume(c context.Context, id string, volume *vo.VolumeVO) (*vo.Volume
 
 	properties := modelcoreutil.ToPropertyModels(volume.Properties)
 	tags := modelcoreutil.ToTagModels(volume.Tags)
-	systemIds := util.Map[vo.SystemVO, string](volume.Systems, func(system vo.SystemVO) *string {
-		return &system.ID
-	})
-	publisherIds := util.Map[vo.PublisherVO, string](volume.Publishers, func(publisher vo.PublisherVO) *string {
-		return &publisher.ID
-	})
-	studioIds := util.Map[vo.StudioVO, string](volume.Studios, func(studio vo.StudioVO) *string {
-		return &studio.ID
-	})
-	licenseIds := util.Map[vo.LicenseVO, string](volume.Licenses, func(license vo.LicenseVO) *string {
-		return &license.ID
-	})
+	systemIds := relationIDs(volume.Systems, func(s *vo.SystemVO) string { return s.ID })
+	publisherIds := relationIDs(volume.Publishers, func(p *vo.PublisherVO) string { return p.ID })
+	studioIds := relationIDs(volume.Studios, func(s *vo.StudioVO) string { return s.ID })
+	licenseIds := relationIDs(volume.Licenses, func(l *vo.LicenseVO) string { return l.ID })
 
 	model := models.Volume{
 		ID:           id,
@@ -192,35 +175,65 @@ func GetVolume(c context.Context, id string) (*vo.VolumeVO, error) {
 	return volumeModelToVO(c, results[0]), nil
 }
 
+// relationIDs extracts each element's ID from a pointer-slice relationship field - the
+// counterpart to the *ByIDs functions below, which resolve IDs back into VOs. Both directions
+// live here rather than using util.Map (which always dereferences into a value slice) since
+// VolumeVO's relationship fields are pointer slices - see that struct's own doc comment for why.
+func relationIDs[T any](relations []*T, id func(*T) string) []string {
+	ids := make([]string, 0, len(relations))
+	for _, r := range relations {
+		if r != nil {
+			ids = append(ids, id(r))
+		}
+	}
+	return ids
+}
+
 func volumeModelToVO(c context.Context, model *models.Volume) *vo.VolumeVO {
-	systemVOs := util.Map[string, vo.SystemVO](model.SystemIds, func(id string) *vo.SystemVO {
-		vo, err := GetSystem(c, id)
+	systemVOs := make([]*vo.SystemVO, 0, len(model.SystemIds))
+	for _, id := range model.SystemIds {
+		system, err := GetSystem(c, id)
 		if err != nil {
 			logging.Logger.Error(fmt.Sprintf("No System found from Volume for ID %s: %s", id, err.Error()))
+			continue
 		}
-		return vo
-	})
-	publisherVOs := util.Map[string, vo.PublisherVO](model.PublisherIds, func(id string) *vo.PublisherVO {
-		vo, err := GetPublisher(c, id)
+		if system != nil {
+			systemVOs = append(systemVOs, system)
+		}
+	}
+	publisherVOs := make([]*vo.PublisherVO, 0, len(model.PublisherIds))
+	for _, id := range model.PublisherIds {
+		publisher, err := GetPublisher(c, id)
 		if err != nil {
 			logging.Logger.Error(fmt.Sprintf("No Publisher found from Volume for ID %s: %s", id, err.Error()))
+			continue
 		}
-		return vo
-	})
-	studioVOs := util.Map[string, vo.StudioVO](model.StudioIds, func(id string) *vo.StudioVO {
-		vo, err := GetStudio(c, id)
+		if publisher != nil {
+			publisherVOs = append(publisherVOs, publisher)
+		}
+	}
+	studioVOs := make([]*vo.StudioVO, 0, len(model.StudioIds))
+	for _, id := range model.StudioIds {
+		studio, err := GetStudio(c, id)
 		if err != nil {
 			logging.Logger.Error(fmt.Sprintf("No Studio found from Volume for ID %s: %s", id, err.Error()))
+			continue
 		}
-		return vo
-	})
-	licenseVOs := util.Map[string, vo.LicenseVO](model.LicenseIds, func(id string) *vo.LicenseVO {
-		vo, err := GetLicense(c, id)
+		if studio != nil {
+			studioVOs = append(studioVOs, studio)
+		}
+	}
+	licenseVOs := make([]*vo.LicenseVO, 0, len(model.LicenseIds))
+	for _, id := range model.LicenseIds {
+		license, err := GetLicense(c, id)
 		if err != nil {
 			logging.Logger.Error(fmt.Sprintf("No License found from Volume for ID %s: %s", id, err.Error()))
+			continue
 		}
-		return vo
-	})
+		if license != nil {
+			licenseVOs = append(licenseVOs, license)
+		}
+	}
 
 	return &vo.VolumeVO{
 		ID:          model.ID,

--- a/data/volume_test.go
+++ b/data/volume_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	apiutil "github.com/sweetrpg/api-core.go/util"
+	"github.com/sweetrpg/catalog-objects.go/models"
 	"github.com/sweetrpg/catalog-objects.go/vo"
 	"github.com/sweetrpg/common.go/logging"
 	"github.com/sweetrpg/mongodb.go/constants"
@@ -135,6 +136,32 @@ func (suite *VolumeDataTestSuite) TestUpdateVolumeNotFound() {
 	})
 	assert.NoError(suite.T(), err)
 	assert.Nil(suite.T(), updated)
+}
+
+// TestUpdateVolumeWithPublisherRelationship guards against a regression: VolumeVO.Publishers
+// used to be a value slice ([]PublisherVO), which panicked when a caller further up the stack
+// (catalog-api) marshaled it via the jsonapi library - a nil-check on a non-pointer struct.
+// UpdateVolume/GetVolume don't marshal jsonapi themselves, but this confirms the pointer-slice
+// round-trips correctly at this layer, which is the part that regressed.
+func (suite *VolumeDataTestSuite) TestUpdateVolumeWithPublisherRelationship() {
+	_, err := database.Insert("publishers", models.Publisher{ID: "pub-test-1", Name: "Test Publisher"})
+	assert.NoError(suite.T(), err)
+
+	updated, err := UpdateVolume(suite.T().Context(), suite.seedVolumeID, &vo.VolumeVO{
+		Title:      "Volume With Publisher",
+		Publishers: []*vo.PublisherVO{{ID: "pub-test-1"}},
+	})
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), updated)
+	assert.Len(suite.T(), updated.Publishers, 1)
+	assert.Equal(suite.T(), "pub-test-1", updated.Publishers[0].ID)
+
+	fetched, err := GetVolume(suite.T().Context(), suite.seedVolumeID)
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), fetched)
+	assert.Len(suite.T(), fetched.Publishers, 1)
+	assert.Equal(suite.T(), "pub-test-1", fetched.Publishers[0].ID)
+	assert.Equal(suite.T(), "Test Publisher", fetched.Publishers[0].Name)
 }
 
 func (suite *VolumeDataTestSuite) TestQueryVolumesPaged() {

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/stretchr/testify v1.11.1
 	github.com/sweetrpg/api-core.go v0.0.436
-	github.com/sweetrpg/catalog-objects.go v0.0.196
+	github.com/sweetrpg/catalog-objects.go v0.0.197
 	github.com/sweetrpg/common.go v0.0.16
 	github.com/sweetrpg/model-core.go v0.0.173
 	github.com/sweetrpg/mongodb.go v0.0.193

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/sweetrpg/api-core.go v0.0.436 h1:sCMdy9f82Y3RMtlQOnYljQ3dFjaLR3qvgyNJmME9nq0=
 github.com/sweetrpg/api-core.go v0.0.436/go.mod h1:hWjWppLsrQ8R+u3FD8NjJo+uuxkEeGJx2DOlQO0XGm4=
-github.com/sweetrpg/catalog-objects.go v0.0.196 h1:JVHFT/sIU/jobAsgssU0YRggo2Filo64ilC/aXoEfj0=
-github.com/sweetrpg/catalog-objects.go v0.0.196/go.mod h1:wtpjoqkJZBjK4tN0vCpFkuKLf6aUWpADj/MFC6Gufvc=
+github.com/sweetrpg/catalog-objects.go v0.0.197 h1:jTfa8eNBbRScRTEq17V3Mgt/NErjA07VFvhuh9pyUtA=
+github.com/sweetrpg/catalog-objects.go v0.0.197/go.mod h1:wtpjoqkJZBjK4tN0vCpFkuKLf6aUWpADj/MFC6Gufvc=
 github.com/sweetrpg/common.go v0.0.16 h1:XT8PwUXz0BOMIITXLjw3G6rEjjRUEs0Xs4+R9o2fVBk=
 github.com/sweetrpg/common.go v0.0.16/go.mod h1:PVpjDIeB/bZYJZk5fc8whuqVJE8K5k/DsO3o+aZFEcE=
 github.com/sweetrpg/model-core.go v0.0.173 h1:mIZ4z0ETkCH7I3Az0jwTFOyh66OTm7Z4/f0Rx/w+5Fk=


### PR DESCRIPTION
## Summary
- catalog-objects.go v0.0.197 changed VolumeVO's Systems/Publishers/Studios/Licenses fields from value slices to pointer slices, fixing a jsonapi relationship-marshaling panic that surfaced when publisher/studio linking was exercised for the first time (durable-volume-editing, sweetrpg/platform#38).
- Update AddVolume/UpdateVolume/volumeModelToVO to build/consume []*vo.XVO instead of relying on common.go/util.Map, which can only produce value slices.
- Add TestUpdateVolumeWithPublisherRelationship to guard the regression at this layer.

## Test plan
- [x] go build ./... and go vet ./... clean
- [x] Full TestDbTestSuite (12/12) passes against local MongoDB with the real published catalog-objects.go v0.0.197 dependency (no local replace directive)

Part of `openspec/changes/durable-volume-editing`.