### PR TITLE
feat(contribution): add write path (Add/Delete/QueryByVolume)

### DIFF
--- a/data/contribution.go
+++ b/data/contribution.go
@@ -3,15 +3,18 @@ package data
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/sweetrpg/api-core.go/tracing"
 	apiutil "github.com/sweetrpg/api-core.go/util"
 	"github.com/sweetrpg/catalog-objects.go/models"
 	"github.com/sweetrpg/catalog-objects.go/vo"
 	"github.com/sweetrpg/common.go/logging"
+	modelcore "github.com/sweetrpg/model-core.go/models"
 	modelcorevo "github.com/sweetrpg/model-core.go/vo"
 	"github.com/sweetrpg/mongodb.go/database"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	oteltrace "go.opentelemetry.io/otel/trace"
@@ -88,4 +91,62 @@ func QueryContributions(c context.Context, params apiutil.QueryParams) ([]*vo.Co
 	}
 
 	return vos, nil
+}
+
+// QueryContributionsByVolume returns every contribution credited to volumeID.
+func QueryContributionsByVolume(c context.Context, volumeID string) ([]*vo.ContributionVO, error) {
+	_, span := otel.Tracer("contribution").Start(c, "db-query-contributions-by-volume", oteltrace.WithAttributes(attribute.String("volumeId", volumeID)))
+	results, err := database.Query[models.Contribution]("contributions", bson.D{{Key: "volume_id", Value: volumeID}}, nil, nil, 0, 0)
+	span.End()
+	if err != nil {
+		logging.Logger.Error("Error while querying database for Contributions by volume", "error", err)
+		return nil, err
+	}
+
+	vos := make([]*vo.ContributionVO, 0, len(results))
+	for _, model := range results {
+		vos = append(vos, contributionModelToVO(c, model))
+	}
+	return vos, nil
+}
+
+// AddContribution creates a new person-to-volume credit and returns its ID.
+func AddContribution(c context.Context, personID, volumeID string, roles []string, createdBy string) (*string, error) {
+	_, span := otel.Tracer("contribution").Start(c, "db-add-contribution", oteltrace.WithAttributes(
+		attribute.String("personId", personID), attribute.String("volumeId", volumeID)))
+	defer span.End()
+
+	now := time.Now()
+	model := models.Contribution{
+		ID:       primitive.NewObjectID().Hex(),
+		PersonId: personID,
+		VolumeId: volumeID,
+		Roles:    roles,
+		Auditable: modelcore.Auditable{
+			CreatedAt: now,
+			CreatedBy: createdBy,
+			UpdatedAt: now,
+			UpdatedBy: createdBy,
+		},
+	}
+
+	if _, err := database.Insert[models.Contribution]("contributions", model); err != nil {
+		logging.Logger.Error("Error while inserting Contribution", "error", err)
+		return nil, err
+	}
+	return &model.ID, nil
+}
+
+// DeleteContribution removes a person-to-volume credit by ID. Returns false if no matching
+// document existed.
+func DeleteContribution(c context.Context, id string) (bool, error) {
+	_, span := otel.Tracer("contribution").Start(c, "db-delete-contribution", oteltrace.WithAttributes(attribute.String("id", id)))
+	defer span.End()
+
+	result, err := database.Db.Collection("contributions").DeleteOne(c, bson.D{{Key: "_id", Value: id}})
+	if err != nil {
+		logging.Logger.Error("Error while deleting Contribution", "error", err)
+		return false, err
+	}
+	return result.DeletedCount > 0, nil
 }

--- a/data/contribution_test.go
+++ b/data/contribution_test.go
@@ -1,0 +1,56 @@
+package data
+
+import (
+	"github.com/stretchr/testify/assert"
+	catalogmodels "github.com/sweetrpg/catalog-objects.go/models"
+	"github.com/sweetrpg/mongodb.go/database"
+)
+
+// These live as methods on VolumeDataTestSuite (defined in volume_test.go) rather than
+// standalone Test* funcs so they pick up SetupTest's logging.Init()/database.SetupDatabase()
+// call - this package has no package-level TestMain of its own.
+
+func (suite *VolumeDataTestSuite) TestAddContributionAndQueryByVolume() {
+	ctx := suite.T().Context()
+
+	_, err := database.Insert("persons", catalogmodels.Person{ID: "person-contrib-1", Name: "Test Author"})
+	assert.NoError(suite.T(), err)
+
+	id, err := AddContribution(ctx, "person-contrib-1", suite.seedVolumeID, []string{"Author"}, "auth0|editor")
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), id)
+	assert.NotEmpty(suite.T(), *id)
+
+	contributions, err := QueryContributionsByVolume(ctx, suite.seedVolumeID)
+	assert.NoError(suite.T(), err)
+	assert.Len(suite.T(), contributions, 1)
+	assert.Equal(suite.T(), "person-contrib-1", contributions[0].Person.ID)
+	assert.Equal(suite.T(), []string{"Author"}, contributions[0].Roles)
+
+	got, err := GetContribution(ctx, *id)
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), got)
+	assert.Equal(suite.T(), *id, got.ID)
+}
+
+func (suite *VolumeDataTestSuite) TestDeleteContribution() {
+	ctx := suite.T().Context()
+
+	_, err := database.Insert("persons", catalogmodels.Person{ID: "person-contrib-2", Name: "Another Author"})
+	assert.NoError(suite.T(), err)
+
+	id, err := AddContribution(ctx, "person-contrib-2", suite.seedVolumeID, []string{"Editor"}, "auth0|editor")
+	assert.NoError(suite.T(), err)
+
+	deleted, err := DeleteContribution(ctx, *id)
+	assert.NoError(suite.T(), err)
+	assert.True(suite.T(), deleted)
+
+	got, err := GetContribution(ctx, *id)
+	assert.NoError(suite.T(), err)
+	assert.Nil(suite.T(), got)
+
+	deletedAgain, err := DeleteContribution(ctx, *id)
+	assert.NoError(suite.T(), err)
+	assert.False(suite.T(), deletedAgain)
+}


### PR DESCRIPTION
## Summary
Contribution previously had no write path at all (only Get/Query, per this repo's own AGENTS.md "Known gaps"). Adds:
- `AddContribution(ctx, personID, volumeID, roles, createdBy)` - creates a new credit
- `DeleteContribution(ctx, id)` - removes one, returns whether it existed
- `QueryContributionsByVolume(ctx, volumeID)` - lists a volume's credits

Matches Volume's existing pattern (string `_id` via `primitive.NewObjectID().Hex()`). Needed for catalog-api's upcoming contributor-credit endpoints (durable-volume-editing task 4.2).

## Test plan
- [x] `go build ./...` and `go vet ./...` clean
- [x] Full suite (14/14) passes against local MongoDB

Part of `openspec/changes/durable-volume-editing` (sweetrpg/platform#38).