### PR TITLE
Add write path (Update) for publisher, studio, person, and license

### DIFF
--- a/data/license.go
+++ b/data/license.go
@@ -3,12 +3,14 @@ package data
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/sweetrpg/api-core.go/tracing"
 	apiutil "github.com/sweetrpg/api-core.go/util"
 	"github.com/sweetrpg/catalog-objects.go/models"
 	"github.com/sweetrpg/catalog-objects.go/vo"
 	"github.com/sweetrpg/common.go/logging"
+	modelcore "github.com/sweetrpg/model-core.go/models"
 	modelcoreutil "github.com/sweetrpg/model-core.go/util"
 	modelcorevo "github.com/sweetrpg/model-core.go/vo"
 	"github.com/sweetrpg/mongodb.go/database"
@@ -58,6 +60,73 @@ func licenseModelToVO(model *models.License) *vo.LicenseVO {
 			DeletedBy: model.DeletedBy,
 		},
 	}
+}
+
+// UpdateLicense merges the provided fields into the existing license and writes it, mirroring
+// UpdatePublisher's raw-marshal $set approach.
+func UpdateLicense(c context.Context, id string, license *vo.LicenseVO) (*vo.LicenseVO, error) {
+	_, span := otel.Tracer("license").Start(c, "db-update-license", oteltrace.WithAttributes(attribute.String("id", id)))
+	defer span.End()
+
+	existing, err := GetLicense(c, id)
+	if err != nil {
+		logging.Logger.Error("Error while looking up existing License for update", "id", id, "error", err)
+		return nil, err
+	}
+	if existing == nil {
+		logging.Logger.Info(fmt.Sprintf("License not found for update, ID: %s", id))
+		return nil, nil
+	}
+
+	model := models.License{
+		ID:           id,
+		Title:        license.Title,
+		ShortTitle:   license.ShortTitle,
+		Version:      license.Version,
+		Deed:         license.Deed,
+		LegalCode:    license.LegalCode,
+		Website:      license.Website,
+		Status:       license.Status,
+		Availability: license.Availability,
+		Notes:        license.Notes,
+		Properties:   modelcoreutil.ToPropertyModels(license.Properties),
+		Tags:         modelcoreutil.ToTagModels(license.Tags),
+		Auditable: modelcore.Auditable{
+			CreatedAt: existing.CreatedAt,
+			CreatedBy: existing.CreatedBy,
+			UpdatedAt: time.Now(),
+			UpdatedBy: license.UpdatedBy,
+			DeletedAt: nil,
+			DeletedBy: nil,
+		},
+	}
+
+	data, err := bson.Marshal(model)
+	if err != nil {
+		logging.Logger.Error("Error while preparing License document for update", "error", err)
+		return nil, err
+	}
+	var update bson.D
+	if err := bson.Unmarshal(data, &update); err != nil {
+		logging.Logger.Error("Error while unmarshaling License document for update", "error", err)
+		return nil, err
+	}
+
+	result, err := database.Db.Collection("licenses").UpdateOne(
+		c,
+		bson.D{{Key: "_id", Value: id}},
+		bson.D{{Key: "$set", Value: update}},
+	)
+	if err != nil {
+		logging.Logger.Error("Error while updating License in database", "id", id, "error", err)
+		return nil, err
+	}
+	if result.MatchedCount == 0 {
+		logging.Logger.Info(fmt.Sprintf("License not found for update, ID: %s", id))
+		return nil, nil
+	}
+
+	return GetLicense(c, id)
 }
 
 func QueryLicenses(c context.Context, params apiutil.QueryParams) ([]*vo.LicenseVO, error) {

--- a/data/license_test.go
+++ b/data/license_test.go
@@ -1,0 +1,67 @@
+package data
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"github.com/sweetrpg/catalog-objects.go/models"
+	"github.com/sweetrpg/catalog-objects.go/vo"
+	"github.com/sweetrpg/common.go/logging"
+	"github.com/sweetrpg/mongodb.go/constants"
+	"github.com/sweetrpg/mongodb.go/database"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+const seedLicenseID = "seed-license"
+
+type LicenseDataTestSuite struct {
+	suite.Suite
+}
+
+func (suite *LicenseDataTestSuite) SetupTest() {
+	_ = os.Setenv(constants.DB_URI, os.Getenv("TEST_DB_URI"))
+	logging.Init()
+	database.SetupDatabase()
+
+	_, err := database.Insert[models.License]("licenses", models.License{
+		ID:     seedLicenseID,
+		Title:  "Test License",
+		Status: "draft",
+	})
+	assert.NoError(suite.T(), err)
+}
+
+func (suite *LicenseDataTestSuite) TearDownTest() {
+	_, _ = database.Db.Collection("licenses").DeleteMany(
+		suite.T().Context(), bson.D{{Key: "_id", Value: seedLicenseID}})
+}
+
+func (suite *LicenseDataTestSuite) TestUpdateLicense() {
+	updated, err := UpdateLicense(suite.T().Context(), seedLicenseID, &vo.LicenseVO{
+		Title:  "Updated License",
+		Status: "active",
+	})
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), updated)
+	assert.Equal(suite.T(), "Updated License", updated.Title)
+	assert.Equal(suite.T(), "active", updated.Status)
+
+	fetched, err := GetLicense(suite.T().Context(), seedLicenseID)
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), fetched)
+	assert.Equal(suite.T(), "Updated License", fetched.Title)
+}
+
+func (suite *LicenseDataTestSuite) TestUpdateLicenseNotFound() {
+	updated, err := UpdateLicense(suite.T().Context(), "does-not-exist", &vo.LicenseVO{
+		Title: "Doesn't Matter",
+	})
+	assert.NoError(suite.T(), err)
+	assert.Nil(suite.T(), updated)
+}
+
+func TestLicenseDbTestSuite(t *testing.T) {
+	suite.Run(t, new(LicenseDataTestSuite))
+}

--- a/data/person.go
+++ b/data/person.go
@@ -3,12 +3,14 @@ package data
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/sweetrpg/api-core.go/tracing"
 	apiutil "github.com/sweetrpg/api-core.go/util"
 	"github.com/sweetrpg/catalog-objects.go/models"
 	"github.com/sweetrpg/catalog-objects.go/vo"
 	"github.com/sweetrpg/common.go/logging"
+	modelcore "github.com/sweetrpg/model-core.go/models"
 	modelcoreutil "github.com/sweetrpg/model-core.go/util"
 	modelcorevo "github.com/sweetrpg/model-core.go/vo"
 	"github.com/sweetrpg/mongodb.go/database"
@@ -51,6 +53,66 @@ func personModelToVO(model *models.Person) *vo.PersonVO {
 			DeletedBy: model.DeletedBy,
 		},
 	}
+}
+
+// UpdatePerson merges the provided fields into the existing person and writes it, mirroring
+// UpdatePublisher's raw-marshal $set approach.
+func UpdatePerson(c context.Context, id string, person *vo.PersonVO) (*vo.PersonVO, error) {
+	_, span := otel.Tracer("person").Start(c, "db-update-person", oteltrace.WithAttributes(attribute.String("id", id)))
+	defer span.End()
+
+	existing, err := GetPerson(c, id)
+	if err != nil {
+		logging.Logger.Error("Error while looking up existing Person for update", "id", id, "error", err)
+		return nil, err
+	}
+	if existing == nil {
+		logging.Logger.Info(fmt.Sprintf("Person not found for update, ID: %s", id))
+		return nil, nil
+	}
+
+	model := models.Person{
+		ID:         id,
+		Name:       person.Name,
+		Notes:      person.Notes,
+		Properties: modelcoreutil.ToPropertyModels(person.Properties),
+		Tags:       modelcoreutil.ToTagModels(person.Tags),
+		Auditable: modelcore.Auditable{
+			CreatedAt: existing.CreatedAt,
+			CreatedBy: existing.CreatedBy,
+			UpdatedAt: time.Now(),
+			UpdatedBy: person.UpdatedBy,
+			DeletedAt: nil,
+			DeletedBy: nil,
+		},
+	}
+
+	data, err := bson.Marshal(model)
+	if err != nil {
+		logging.Logger.Error("Error while preparing Person document for update", "error", err)
+		return nil, err
+	}
+	var update bson.D
+	if err := bson.Unmarshal(data, &update); err != nil {
+		logging.Logger.Error("Error while unmarshaling Person document for update", "error", err)
+		return nil, err
+	}
+
+	result, err := database.Db.Collection("persons").UpdateOne(
+		c,
+		bson.D{{Key: "_id", Value: id}},
+		bson.D{{Key: "$set", Value: update}},
+	)
+	if err != nil {
+		logging.Logger.Error("Error while updating Person in database", "id", id, "error", err)
+		return nil, err
+	}
+	if result.MatchedCount == 0 {
+		logging.Logger.Info(fmt.Sprintf("Person not found for update, ID: %s", id))
+		return nil, nil
+	}
+
+	return GetPerson(c, id)
 }
 
 func QueryPersons(c context.Context, params apiutil.QueryParams) ([]*vo.PersonVO, error) {

--- a/data/person_test.go
+++ b/data/person_test.go
@@ -1,0 +1,64 @@
+package data
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"github.com/sweetrpg/catalog-objects.go/models"
+	"github.com/sweetrpg/catalog-objects.go/vo"
+	"github.com/sweetrpg/common.go/logging"
+	"github.com/sweetrpg/mongodb.go/constants"
+	"github.com/sweetrpg/mongodb.go/database"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+const seedPersonID = "seed-person"
+
+type PersonDataTestSuite struct {
+	suite.Suite
+}
+
+func (suite *PersonDataTestSuite) SetupTest() {
+	_ = os.Setenv(constants.DB_URI, os.Getenv("TEST_DB_URI"))
+	logging.Init()
+	database.SetupDatabase()
+
+	_, err := database.Insert[models.Person]("persons", models.Person{
+		ID:   seedPersonID,
+		Name: "Test Person",
+	})
+	assert.NoError(suite.T(), err)
+}
+
+func (suite *PersonDataTestSuite) TearDownTest() {
+	_, _ = database.Db.Collection("persons").DeleteMany(
+		suite.T().Context(), bson.D{{Key: "_id", Value: seedPersonID}})
+}
+
+func (suite *PersonDataTestSuite) TestUpdatePerson() {
+	updated, err := UpdatePerson(suite.T().Context(), seedPersonID, &vo.PersonVO{
+		Name: "Updated Person",
+	})
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), updated)
+	assert.Equal(suite.T(), "Updated Person", updated.Name)
+
+	fetched, err := GetPerson(suite.T().Context(), seedPersonID)
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), fetched)
+	assert.Equal(suite.T(), "Updated Person", fetched.Name)
+}
+
+func (suite *PersonDataTestSuite) TestUpdatePersonNotFound() {
+	updated, err := UpdatePerson(suite.T().Context(), "does-not-exist", &vo.PersonVO{
+		Name: "Doesn't Matter",
+	})
+	assert.NoError(suite.T(), err)
+	assert.Nil(suite.T(), updated)
+}
+
+func TestPersonDbTestSuite(t *testing.T) {
+	suite.Run(t, new(PersonDataTestSuite))
+}

--- a/data/publisher.go
+++ b/data/publisher.go
@@ -3,12 +3,14 @@ package data
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/sweetrpg/api-core.go/tracing"
 	apiutil "github.com/sweetrpg/api-core.go/util"
 	"github.com/sweetrpg/catalog-objects.go/models"
 	"github.com/sweetrpg/catalog-objects.go/vo"
 	"github.com/sweetrpg/common.go/logging"
+	modelcore "github.com/sweetrpg/model-core.go/models"
 	modelcoreutil "github.com/sweetrpg/model-core.go/util"
 	modelcorevo "github.com/sweetrpg/model-core.go/vo"
 	"github.com/sweetrpg/mongodb.go/database"
@@ -53,6 +55,69 @@ func publisherModelToVO(model *models.Publisher) *vo.PublisherVO {
 			DeletedBy: model.DeletedBy,
 		},
 	}
+}
+
+// UpdatePublisher merges the provided fields into the existing publisher and writes it, mirroring
+// UpdateVolume's raw-marshal $set approach (there's no generic update path since the "_id" field
+// is a plain string, not a primitive.ObjectID, so database.Update[T] doesn't apply here).
+func UpdatePublisher(c context.Context, id string, publisher *vo.PublisherVO) (*vo.PublisherVO, error) {
+	_, span := otel.Tracer("publisher").Start(c, "db-update-publisher", oteltrace.WithAttributes(attribute.String("id", id)))
+	defer span.End()
+
+	existing, err := GetPublisher(c, id)
+	if err != nil {
+		logging.Logger.Error("Error while looking up existing Publisher for update", "id", id, "error", err)
+		return nil, err
+	}
+	if existing == nil {
+		logging.Logger.Info(fmt.Sprintf("Publisher not found for update, ID: %s", id))
+		return nil, nil
+	}
+
+	model := models.Publisher{
+		ID:         id,
+		Name:       publisher.Name,
+		Address:    publisher.Address,
+		Website:    publisher.Website,
+		Notes:      publisher.Notes,
+		Properties: modelcoreutil.ToPropertyModels(publisher.Properties),
+		Tags:       modelcoreutil.ToTagModels(publisher.Tags),
+		Auditable: modelcore.Auditable{
+			CreatedAt: existing.CreatedAt,
+			CreatedBy: existing.CreatedBy,
+			UpdatedAt: time.Now(),
+			UpdatedBy: publisher.UpdatedBy,
+			DeletedAt: nil,
+			DeletedBy: nil,
+		},
+	}
+
+	data, err := bson.Marshal(model)
+	if err != nil {
+		logging.Logger.Error("Error while preparing Publisher document for update", "error", err)
+		return nil, err
+	}
+	var update bson.D
+	if err := bson.Unmarshal(data, &update); err != nil {
+		logging.Logger.Error("Error while unmarshaling Publisher document for update", "error", err)
+		return nil, err
+	}
+
+	result, err := database.Db.Collection("publishers").UpdateOne(
+		c,
+		bson.D{{Key: "_id", Value: id}},
+		bson.D{{Key: "$set", Value: update}},
+	)
+	if err != nil {
+		logging.Logger.Error("Error while updating Publisher in database", "id", id, "error", err)
+		return nil, err
+	}
+	if result.MatchedCount == 0 {
+		logging.Logger.Info(fmt.Sprintf("Publisher not found for update, ID: %s", id))
+		return nil, nil
+	}
+
+	return GetPublisher(c, id)
 }
 
 func QueryPublishers(c context.Context, params apiutil.QueryParams) ([]*vo.PublisherVO, error) {

--- a/data/publisher_test.go
+++ b/data/publisher_test.go
@@ -1,0 +1,70 @@
+package data
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"github.com/sweetrpg/catalog-objects.go/models"
+	"github.com/sweetrpg/catalog-objects.go/vo"
+	"github.com/sweetrpg/common.go/logging"
+	"github.com/sweetrpg/mongodb.go/constants"
+	"github.com/sweetrpg/mongodb.go/database"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+// seedPublisherID is a fixed, non-ObjectID string on purpose - Publisher's "_id" is a plain
+// string field (not a primitive.ObjectID), so database.Insert's ObjectID-typed return value
+// doesn't apply here; the seed document's own ID is used directly instead.
+const seedPublisherID = "seed-publisher"
+
+type PublisherDataTestSuite struct {
+	suite.Suite
+}
+
+func (suite *PublisherDataTestSuite) SetupTest() {
+	_ = os.Setenv(constants.DB_URI, os.Getenv("TEST_DB_URI"))
+	logging.Init()
+	database.SetupDatabase()
+
+	_, err := database.Insert[models.Publisher]("publishers", models.Publisher{
+		ID:      seedPublisherID,
+		Name:    "Test Publisher",
+		Address: "123 Test St",
+	})
+	assert.NoError(suite.T(), err)
+}
+
+func (suite *PublisherDataTestSuite) TearDownTest() {
+	_, _ = database.Db.Collection("publishers").DeleteMany(
+		suite.T().Context(), bson.D{{Key: "_id", Value: seedPublisherID}})
+}
+
+func (suite *PublisherDataTestSuite) TestUpdatePublisher() {
+	updated, err := UpdatePublisher(suite.T().Context(), seedPublisherID, &vo.PublisherVO{
+		Name:    "Updated Publisher",
+		Address: "456 Updated Ave",
+	})
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), updated)
+	assert.Equal(suite.T(), "Updated Publisher", updated.Name)
+	assert.Equal(suite.T(), "456 Updated Ave", updated.Address)
+
+	fetched, err := GetPublisher(suite.T().Context(), seedPublisherID)
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), fetched)
+	assert.Equal(suite.T(), "Updated Publisher", fetched.Name)
+}
+
+func (suite *PublisherDataTestSuite) TestUpdatePublisherNotFound() {
+	updated, err := UpdatePublisher(suite.T().Context(), "does-not-exist", &vo.PublisherVO{
+		Name: "Doesn't Matter",
+	})
+	assert.NoError(suite.T(), err)
+	assert.Nil(suite.T(), updated)
+}
+
+func TestPublisherDbTestSuite(t *testing.T) {
+	suite.Run(t, new(PublisherDataTestSuite))
+}

--- a/data/studio.go
+++ b/data/studio.go
@@ -3,12 +3,14 @@ package data
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/sweetrpg/api-core.go/tracing"
 	apiutil "github.com/sweetrpg/api-core.go/util"
 	"github.com/sweetrpg/catalog-objects.go/models"
 	"github.com/sweetrpg/catalog-objects.go/vo"
 	"github.com/sweetrpg/common.go/logging"
+	modelcore "github.com/sweetrpg/model-core.go/models"
 	modelcoreutil "github.com/sweetrpg/model-core.go/util"
 	modelcorevo "github.com/sweetrpg/model-core.go/vo"
 	"github.com/sweetrpg/mongodb.go/database"
@@ -52,6 +54,67 @@ func studioModelToVO(model *models.Studio) *vo.StudioVO {
 			DeletedBy: model.DeletedBy,
 		},
 	}
+}
+
+// UpdateStudio merges the provided fields into the existing studio and writes it, mirroring
+// UpdatePublisher's raw-marshal $set approach.
+func UpdateStudio(c context.Context, id string, studio *vo.StudioVO) (*vo.StudioVO, error) {
+	_, span := otel.Tracer("studio").Start(c, "db-update-studio", oteltrace.WithAttributes(attribute.String("id", id)))
+	defer span.End()
+
+	existing, err := GetStudio(c, id)
+	if err != nil {
+		logging.Logger.Error("Error while looking up existing Studio for update", "id", id, "error", err)
+		return nil, err
+	}
+	if existing == nil {
+		logging.Logger.Info(fmt.Sprintf("Studio not found for update, ID: %s", id))
+		return nil, nil
+	}
+
+	model := models.Studio{
+		ID:         id,
+		Name:       studio.Name,
+		Website:    studio.Website,
+		Notes:      studio.Notes,
+		Properties: modelcoreutil.ToPropertyModels(studio.Properties),
+		Tags:       modelcoreutil.ToTagModels(studio.Tags),
+		Auditable: modelcore.Auditable{
+			CreatedAt: existing.CreatedAt,
+			CreatedBy: existing.CreatedBy,
+			UpdatedAt: time.Now(),
+			UpdatedBy: studio.UpdatedBy,
+			DeletedAt: nil,
+			DeletedBy: nil,
+		},
+	}
+
+	data, err := bson.Marshal(model)
+	if err != nil {
+		logging.Logger.Error("Error while preparing Studio document for update", "error", err)
+		return nil, err
+	}
+	var update bson.D
+	if err := bson.Unmarshal(data, &update); err != nil {
+		logging.Logger.Error("Error while unmarshaling Studio document for update", "error", err)
+		return nil, err
+	}
+
+	result, err := database.Db.Collection("studios").UpdateOne(
+		c,
+		bson.D{{Key: "_id", Value: id}},
+		bson.D{{Key: "$set", Value: update}},
+	)
+	if err != nil {
+		logging.Logger.Error("Error while updating Studio in database", "id", id, "error", err)
+		return nil, err
+	}
+	if result.MatchedCount == 0 {
+		logging.Logger.Info(fmt.Sprintf("Studio not found for update, ID: %s", id))
+		return nil, nil
+	}
+
+	return GetStudio(c, id)
 }
 
 func QueryStudios(c context.Context, params apiutil.QueryParams) ([]*vo.StudioVO, error) {

--- a/data/studio_test.go
+++ b/data/studio_test.go
@@ -1,0 +1,64 @@
+package data
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"github.com/sweetrpg/catalog-objects.go/models"
+	"github.com/sweetrpg/catalog-objects.go/vo"
+	"github.com/sweetrpg/common.go/logging"
+	"github.com/sweetrpg/mongodb.go/constants"
+	"github.com/sweetrpg/mongodb.go/database"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+const seedStudioID = "seed-studio"
+
+type StudioDataTestSuite struct {
+	suite.Suite
+}
+
+func (suite *StudioDataTestSuite) SetupTest() {
+	_ = os.Setenv(constants.DB_URI, os.Getenv("TEST_DB_URI"))
+	logging.Init()
+	database.SetupDatabase()
+
+	_, err := database.Insert[models.Studio]("studios", models.Studio{
+		ID:   seedStudioID,
+		Name: "Test Studio",
+	})
+	assert.NoError(suite.T(), err)
+}
+
+func (suite *StudioDataTestSuite) TearDownTest() {
+	_, _ = database.Db.Collection("studios").DeleteMany(
+		suite.T().Context(), bson.D{{Key: "_id", Value: seedStudioID}})
+}
+
+func (suite *StudioDataTestSuite) TestUpdateStudio() {
+	updated, err := UpdateStudio(suite.T().Context(), seedStudioID, &vo.StudioVO{
+		Name: "Updated Studio",
+	})
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), updated)
+	assert.Equal(suite.T(), "Updated Studio", updated.Name)
+
+	fetched, err := GetStudio(suite.T().Context(), seedStudioID)
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), fetched)
+	assert.Equal(suite.T(), "Updated Studio", fetched.Name)
+}
+
+func (suite *StudioDataTestSuite) TestUpdateStudioNotFound() {
+	updated, err := UpdateStudio(suite.T().Context(), "does-not-exist", &vo.StudioVO{
+		Name: "Doesn't Matter",
+	})
+	assert.NoError(suite.T(), err)
+	assert.Nil(suite.T(), updated)
+}
+
+func TestStudioDbTestSuite(t *testing.T) {
+	suite.Run(t, new(StudioDataTestSuite))
+}


### PR DESCRIPTION
Closes #26

`UpdatePublisher`/`UpdateStudio`/`UpdatePerson`/`UpdateLicense`, mirroring `UpdateVolume`'s
raw-marshal `$set` approach exactly (fetch existing, merge, marshal to BSON, `$set` via
`UpdateOne`, re-fetch). The generic `database.Update[T]` helper takes a `primitive.ObjectID`,
but these collections' `_id` is a plain string field, so it doesn't apply here - same reason
`UpdateVolume` doesn't use it either.

Mongo-backed test suite per type (`go test` against a local `mongo:7.0` container, all passing),
following `volume_test.go`'s `testify` suite pattern.

Discovered mid-implementation of `catalog-entity-pages` (sweetrpg/platform) - `catalog-api`'s new
`PATCH /:type/:id` endpoints (sweetrpg/catalog-api#185) need this write path first. Unblocks
that work.