### PR TITLE
Rewrite volume data access around meta+version model

### DIFF
--- a/data/volume.go
+++ b/data/volume.go
@@ -66,6 +66,18 @@ func UpdateVolume(c context.Context, id string, volume *vo.VolumeVO, state model
 	_, span := otel.Tracer("volume").Start(c, "db-update-volume", oteltrace.WithAttributes(attribute.String("id", id)))
 	defer span.End()
 
+	return createVolumeVersion(c, id, volume, state, volume.UpdatedBy, time.Now())
+}
+
+// CreateSubmittedVolumeVersion creates a submitted version stamped with a caller-supplied
+// submittedBy/submittedAt, for migrating a pre-versioning proposed_changes entry into the
+// version model - unlike UpdateVolume, which always stamps "now", this preserves the original
+// proposal's submission audit per design.md's Migration Plan.
+func CreateSubmittedVolumeVersion(c context.Context, id string, volume *vo.VolumeVO, submittedBy string, submittedAt time.Time) (*vo.VolumeVersionVO, error) {
+	return createVolumeVersion(c, id, volume, models.VersionStateSubmitted, submittedBy, submittedAt)
+}
+
+func createVolumeVersion(c context.Context, id string, volume *vo.VolumeVO, state models.VersionState, submittedBy string, submittedAt time.Time) (*vo.VolumeVersionVO, error) {
 	meta, err := getVolumeMeta(c, id)
 	if err != nil {
 		logging.Logger.Error("Error while looking up VolumeMeta for update", "id", id, "error", err)
@@ -81,7 +93,6 @@ func UpdateVolume(c context.Context, id string, volume *vo.VolumeVO, state model
 		return nil, err
 	}
 
-	now := time.Now()
 	baseVersion := meta.CurrentVersion
 	newVersion := volumeVOToVersionFields(volume)
 	newVersion.ID = primitive.NewObjectID().Hex()
@@ -89,8 +100,8 @@ func UpdateVolume(c context.Context, id string, volume *vo.VolumeVO, state model
 	newVersion.Version = nextVersion
 	newVersion.State = state
 	newVersion.BaseVersion = &baseVersion
-	newVersion.SubmittedBy = volume.UpdatedBy
-	newVersion.SubmittedAt = now
+	newVersion.SubmittedBy = submittedBy
+	newVersion.SubmittedAt = submittedAt
 
 	if _, err := database.Insert[models.VolumeVersion](volumeVersionCollection, newVersion); err != nil {
 		logging.Logger.Error("Error while inserting VolumeVersion object", "error", err)

--- a/data/volume.go
+++ b/data/volume.go
@@ -10,7 +10,6 @@ import (
 	"github.com/sweetrpg/catalog-objects.go/models"
 	"github.com/sweetrpg/catalog-objects.go/vo"
 	"github.com/sweetrpg/common.go/logging"
-	modelcore "github.com/sweetrpg/model-core.go/models"
 	modelcoreutil "github.com/sweetrpg/model-core.go/util"
 	modelcorevo "github.com/sweetrpg/model-core.go/vo"
 	"github.com/sweetrpg/mongodb.go/database"
@@ -21,137 +20,93 @@ import (
 	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
+// AddVolume creates a volume's meta record and its first (live) version.
 func AddVolume(c context.Context, volume *vo.VolumeVO) (*string, error) {
 	logging.Logger.Info("AddVolume", "c", c, "volume", volume)
 
 	_, span := otel.Tracer("volume").Start(c, "db-add-volume", oteltrace.WithAttributes())
-
-	properties := modelcoreutil.ToPropertyModels(volume.Properties)
-	logging.Logger.Debug("ToPropertyModels", "properties", properties)
-	tags := modelcoreutil.ToTagModels(volume.Tags)
-	logging.Logger.Debug("ToTagModels", "tags", tags)
-	systemIds := relationIDs(volume.Systems, func(s *vo.SystemVO) string { return s.ID })
-	logging.Logger.Debug("map systems", "systemIds", systemIds)
-	publisherIds := relationIDs(volume.Publishers, func(p *vo.PublisherVO) string { return p.ID })
-	logging.Logger.Debug("map publishers", "publisherIds", publisherIds)
-	studioIds := relationIDs(volume.Studios, func(s *vo.StudioVO) string { return s.ID })
-	logging.Logger.Debug("map studios", "studioIds", studioIds)
-	licenseIds := relationIDs(volume.Licenses, func(l *vo.LicenseVO) string { return l.ID })
-	logging.Logger.Debug("map licenses", "licenseIds", licenseIds)
+	defer span.End()
 
 	now := time.Now()
-	model := models.Volume{
-		ID:             primitive.NewObjectID().Hex(),
-		Title:          volume.Title,
-		Description:    volume.Description,
-		Notes:          volume.Notes,
-		Format:         volume.Format,
-		CoverAssetId:   volume.CoverAssetId,
-		SampleAssetIds: volume.SampleAssetIds,
-		Properties:     properties,
-		Tags:           tags,
-		SystemIds:      systemIds,
-		PublisherIds:   publisherIds,
-		StudioIds:      studioIds,
-		LicenseIds:     licenseIds,
-		Auditable: modelcore.Auditable{
-			CreatedAt: now,
-			CreatedBy: volume.CreatedBy,
-			UpdatedAt: now,
-			UpdatedBy: volume.UpdatedBy,
-			DeletedAt: nil,
-			DeletedBy: nil,
-		},
+	metaID := primitive.NewObjectID().Hex()
+	meta := models.VolumeMeta{
+		ID:             metaID,
+		CurrentVersion: 1,
+		CreatedAt:      now,
+		CreatedBy:      volume.CreatedBy,
 	}
-	logging.Logger.Debug("Volume model", "model", model)
-
-	_, err := database.Insert[models.Volume]("volumes", model)
-	logging.Logger.Debug("Inserted Volume", "id", model.ID, "err", err)
-	if err != nil {
-		logging.Logger.Error("Error while inserting Volume object", "error", err)
+	if _, err := database.Insert[models.VolumeMeta](volumeMetaCollection, meta); err != nil {
+		logging.Logger.Error("Error while inserting VolumeMeta object", "error", err)
 		return nil, err
 	}
 
-	span.End()
+	version := volumeVOToVersionFields(volume)
+	version.ID = primitive.NewObjectID().Hex()
+	version.RecordID = metaID
+	version.Version = 1
+	version.State = models.VersionStateLive
+	version.BaseVersion = nil
+	version.SubmittedBy = volume.CreatedBy
+	version.SubmittedAt = now
+	if _, err := database.Insert[models.VolumeVersion](volumeVersionCollection, version); err != nil {
+		logging.Logger.Error("Error while inserting VolumeVersion object", "error", err)
+		return nil, err
+	}
 
-	return &model.ID, nil
+	return &metaID, nil
 }
 
-func UpdateVolume(c context.Context, id string, volume *vo.VolumeVO) (*vo.VolumeVO, error) {
-	logging.Logger.Info("UpdateVolume", "c", c, "id", id, "volume", volume)
+// UpdateVolume creates a new version of the volume rather than mutating the record in place.
+// For state VersionStateLive, the new version becomes current immediately and the previously
+// current version is archived; any other state (VersionStateSubmitted) leaves the current
+// pointer untouched. Returns the created version, or nil if the record doesn't exist.
+func UpdateVolume(c context.Context, id string, volume *vo.VolumeVO, state models.VersionState) (*vo.VolumeVersionVO, error) {
+	logging.Logger.Info("UpdateVolume", "c", c, "id", id, "volume", volume, "state", state)
 
 	_, span := otel.Tracer("volume").Start(c, "db-update-volume", oteltrace.WithAttributes(attribute.String("id", id)))
 	defer span.End()
 
-	existing, err := GetVolume(c, id)
+	meta, err := getVolumeMeta(c, id)
 	if err != nil {
-		logging.Logger.Error("Error while looking up existing Volume for update", "id", id, "error", err)
+		logging.Logger.Error("Error while looking up VolumeMeta for update", "id", id, "error", err)
 		return nil, err
 	}
-	if existing == nil {
+	if meta == nil {
 		logging.Logger.Info(fmt.Sprintf("Volume not found for update, ID: %s", id))
 		return nil, nil
 	}
 
-	properties := modelcoreutil.ToPropertyModels(volume.Properties)
-	tags := modelcoreutil.ToTagModels(volume.Tags)
-	systemIds := relationIDs(volume.Systems, func(s *vo.SystemVO) string { return s.ID })
-	publisherIds := relationIDs(volume.Publishers, func(p *vo.PublisherVO) string { return p.ID })
-	studioIds := relationIDs(volume.Studios, func(s *vo.StudioVO) string { return s.ID })
-	licenseIds := relationIDs(volume.Licenses, func(l *vo.LicenseVO) string { return l.ID })
-
-	model := models.Volume{
-		ID:             id,
-		Title:          volume.Title,
-		Description:    volume.Description,
-		Notes:          volume.Notes,
-		Format:         volume.Format,
-		CoverAssetId:   volume.CoverAssetId,
-		SampleAssetIds: volume.SampleAssetIds,
-		Properties:     properties,
-		Tags:           tags,
-		SystemIds:      systemIds,
-		PublisherIds:   publisherIds,
-		StudioIds:      studioIds,
-		LicenseIds:     licenseIds,
-		Auditable: modelcore.Auditable{
-			CreatedAt: existing.CreatedAt,
-			CreatedBy: existing.CreatedBy,
-			UpdatedAt: time.Now(),
-			UpdatedBy: volume.UpdatedBy,
-			DeletedAt: nil,
-			DeletedBy: nil,
-		},
-	}
-	logging.Logger.Debug("Volume model for update", "model", model)
-
-	data, err := bson.Marshal(model)
+	nextVersion, err := nextVolumeVersionNumber(c, id)
 	if err != nil {
-		logging.Logger.Error("Error while preparing Volume document for update", "error", err)
-		return nil, err
-	}
-	var update bson.D
-	if err := bson.Unmarshal(data, &update); err != nil {
-		logging.Logger.Error("Error while unmarshaling Volume document for update", "error", err)
 		return nil, err
 	}
 
-	result, err := database.Db.Collection("volumes").UpdateOne(
-		c,
-		bson.D{{Key: "_id", Value: id}},
-		bson.D{{Key: "$set", Value: update}},
-	)
-	logging.Logger.Debug("update result", "result", result, "err", err)
-	if err != nil {
-		logging.Logger.Error("Error while updating Volume in database", "id", id, "error", err)
+	now := time.Now()
+	baseVersion := meta.CurrentVersion
+	newVersion := volumeVOToVersionFields(volume)
+	newVersion.ID = primitive.NewObjectID().Hex()
+	newVersion.RecordID = id
+	newVersion.Version = nextVersion
+	newVersion.State = state
+	newVersion.BaseVersion = &baseVersion
+	newVersion.SubmittedBy = volume.UpdatedBy
+	newVersion.SubmittedAt = now
+
+	if _, err := database.Insert[models.VolumeVersion](volumeVersionCollection, newVersion); err != nil {
+		logging.Logger.Error("Error while inserting VolumeVersion object", "error", err)
 		return nil, err
 	}
-	if result.MatchedCount == 0 {
-		logging.Logger.Info(fmt.Sprintf("Volume not found for update, ID: %s", id))
-		return nil, nil
+
+	if state == models.VersionStateLive {
+		if err := archiveVolumeVersion(c, id, meta.CurrentVersion); err != nil {
+			return nil, err
+		}
+		if err := setVolumeMetaCurrentVersion(c, id, nextVersion); err != nil {
+			return nil, err
+		}
 	}
 
-	return GetVolume(c, id)
+	return volumeVersionModelToVO(c, &newVersion), nil
 }
 
 func DeleteVolume(c context.Context, id string) error {
@@ -164,21 +119,34 @@ func DeleteVolume(c context.Context, id string) error {
 	return nil
 }
 
+// GetVolume returns the flattened view of a volume - its meta record merged with its current
+// version's data - matching the shape this function returned before meta/version were split.
 func GetVolume(c context.Context, id string) (*vo.VolumeVO, error) {
 	_, span := otel.Tracer("volume").Start(c, "db-get-volume", oteltrace.WithAttributes(attribute.String("id", id)))
-	results, err := database.Query[models.Volume]("volumes", bson.D{{Key: "_id", Value: id}}, nil, nil, 0, 1)
-	span.End()
+	defer span.End()
+
+	meta, err := getVolumeMeta(c, id)
 	if err != nil {
-		logging.Logger.Error(fmt.Sprintf("Error while querying database for Volume: %+v", err))
+		logging.Logger.Error(fmt.Sprintf("Error while querying database for VolumeMeta: %+v", err))
 		return nil, err
 	}
-
-	if len(results) == 0 {
+	if meta == nil {
 		logging.Logger.Info(fmt.Sprintf("Volume not found for ID: %s", id))
 		return nil, nil
 	}
 
-	return volumeModelToVO(c, results[0]), nil
+	version, err := getVolumeVersion(c, id, meta.CurrentVersion)
+	if err != nil {
+		logging.Logger.Error(fmt.Sprintf("Error while querying database for VolumeVersion: %+v", err))
+		return nil, err
+	}
+	if version == nil {
+		err := fmt.Errorf("volume %s: meta points at missing current version %d", id, meta.CurrentVersion)
+		logging.Logger.Error(err.Error())
+		return nil, err
+	}
+
+	return flattenVolume(c, meta, version), nil
 }
 
 // relationIDs extracts each element's ID from a pointer-slice relationship field - the
@@ -195,97 +163,170 @@ func relationIDs[T any](relations []*T, id func(*T) string) []string {
 	return ids
 }
 
-func volumeModelToVO(c context.Context, model *models.Volume) *vo.VolumeVO {
-	systemVOs := make([]*vo.SystemVO, 0, len(model.SystemIds))
-	for _, id := range model.SystemIds {
+func resolveVolumeRelations(c context.Context, systemIds, publisherIds, studioIds, licenseIds []string) (
+	systems []*vo.SystemVO, publishers []*vo.PublisherVO, studios []*vo.StudioVO, licenses []*vo.LicenseVO,
+) {
+	systems = make([]*vo.SystemVO, 0, len(systemIds))
+	for _, id := range systemIds {
 		system, err := GetSystem(c, id)
 		if err != nil {
 			logging.Logger.Error(fmt.Sprintf("No System found from Volume for ID %s: %s", id, err.Error()))
 			continue
 		}
 		if system != nil {
-			systemVOs = append(systemVOs, system)
+			systems = append(systems, system)
 		}
 	}
-	publisherVOs := make([]*vo.PublisherVO, 0, len(model.PublisherIds))
-	for _, id := range model.PublisherIds {
+	publishers = make([]*vo.PublisherVO, 0, len(publisherIds))
+	for _, id := range publisherIds {
 		publisher, err := GetPublisher(c, id)
 		if err != nil {
 			logging.Logger.Error(fmt.Sprintf("No Publisher found from Volume for ID %s: %s", id, err.Error()))
 			continue
 		}
 		if publisher != nil {
-			publisherVOs = append(publisherVOs, publisher)
+			publishers = append(publishers, publisher)
 		}
 	}
-	studioVOs := make([]*vo.StudioVO, 0, len(model.StudioIds))
-	for _, id := range model.StudioIds {
+	studios = make([]*vo.StudioVO, 0, len(studioIds))
+	for _, id := range studioIds {
 		studio, err := GetStudio(c, id)
 		if err != nil {
 			logging.Logger.Error(fmt.Sprintf("No Studio found from Volume for ID %s: %s", id, err.Error()))
 			continue
 		}
 		if studio != nil {
-			studioVOs = append(studioVOs, studio)
+			studios = append(studios, studio)
 		}
 	}
-	licenseVOs := make([]*vo.LicenseVO, 0, len(model.LicenseIds))
-	for _, id := range model.LicenseIds {
+	licenses = make([]*vo.LicenseVO, 0, len(licenseIds))
+	for _, id := range licenseIds {
 		license, err := GetLicense(c, id)
 		if err != nil {
 			logging.Logger.Error(fmt.Sprintf("No License found from Volume for ID %s: %s", id, err.Error()))
 			continue
 		}
 		if license != nil {
-			licenseVOs = append(licenseVOs, license)
+			licenses = append(licenses, license)
 		}
 	}
+	return
+}
+
+// flattenVolume merges a meta record with its current version into the pre-versioning VolumeVO
+// shape: creation/deletion audit comes from meta, the "last updated" audit comes from the
+// version's own submission audit (its most recent live edit).
+func flattenVolume(c context.Context, meta *models.VolumeMeta, version *models.VolumeVersion) *vo.VolumeVO {
+	systems, publishers, studios, licenses := resolveVolumeRelations(c, version.SystemIds, version.PublisherIds, version.StudioIds, version.LicenseIds)
 
 	return &vo.VolumeVO{
-		ID:             model.ID,
-		Title:          model.Title,
-		Description:    model.Description,
-		Notes:          model.Notes,
-		Format:         model.Format,
-		CoverAssetId:   model.CoverAssetId,
-		SampleAssetIds: model.SampleAssetIds,
-		Systems:        systemVOs,
-		Publishers:     publisherVOs,
-		Studios:        studioVOs,
-		Licenses:       licenseVOs,
-		Properties:     modelcoreutil.FromPropertyModels(model.Properties),
-		Tags:           modelcoreutil.FromTagModels(model.Tags),
+		ID:             meta.ID,
+		Title:          version.Title,
+		Description:    version.Description,
+		Notes:          version.Notes,
+		Format:         version.Format,
+		CoverAssetId:   version.CoverAssetId,
+		SampleAssetIds: version.SampleAssetIds,
+		Systems:        systems,
+		Publishers:     publishers,
+		Studios:        studios,
+		Licenses:       licenses,
+		Properties:     modelcoreutil.FromPropertyModels(version.Properties),
+		Tags:           modelcoreutil.FromTagModels(version.Tags),
 		AuditableVO: modelcorevo.AuditableVO{
-			CreatedAt: model.CreatedAt,
-			CreatedBy: model.CreatedBy,
-			UpdatedAt: model.UpdatedAt,
-			UpdatedBy: model.UpdatedBy,
-			DeletedAt: model.DeletedAt,
-			DeletedBy: model.DeletedBy,
+			CreatedAt: meta.CreatedAt,
+			CreatedBy: meta.CreatedBy,
+			UpdatedAt: version.SubmittedAt,
+			UpdatedBy: version.SubmittedBy,
+			DeletedAt: meta.DeletedAt,
+			DeletedBy: meta.DeletedBy,
 		},
 	}
 }
 
+// volumeVersionModelToVO converts a version record on its own (no meta) into the version-history
+// API shape, resolving its relationship IDs the same way a flattened read does.
+func volumeVersionModelToVO(c context.Context, version *models.VolumeVersion) *vo.VolumeVersionVO {
+	systems, publishers, studios, licenses := resolveVolumeRelations(c, version.SystemIds, version.PublisherIds, version.StudioIds, version.LicenseIds)
+
+	return &vo.VolumeVersionVO{
+		ID:               version.ID,
+		RecordID:         version.RecordID,
+		Version:          version.Version,
+		Title:            version.Title,
+		Description:      version.Description,
+		Notes:            version.Notes,
+		Format:           version.Format,
+		CoverAssetId:     version.CoverAssetId,
+		SampleAssetIds:   version.SampleAssetIds,
+		Systems:          systems,
+		Publishers:       publishers,
+		Studios:          studios,
+		Licenses:         licenses,
+		Properties:       modelcoreutil.FromPropertyModels(version.Properties),
+		Tags:             modelcoreutil.FromTagModels(version.Tags),
+		State:            vo.VersionState(version.State),
+		BaseVersion:      version.BaseVersion,
+		SubmittedBy:      version.SubmittedBy,
+		SubmittedAt:      version.SubmittedAt,
+		ReviewedBy:       version.ReviewedBy,
+		ReviewedAt:       version.ReviewedAt,
+		ReviewNote:       version.ReviewNote,
+		ResultingVersion: version.ResultingVersion,
+	}
+}
+
+// volumeVOToVersionFields maps a request VolumeVO's substantive fields onto a new
+// models.VolumeVersion - the caller fills in the version-lifecycle fields (ID, RecordID,
+// Version, State, BaseVersion, SubmittedBy/At).
+func volumeVOToVersionFields(volume *vo.VolumeVO) models.VolumeVersion {
+	return models.VolumeVersion{
+		Title:          volume.Title,
+		Description:    volume.Description,
+		Notes:          volume.Notes,
+		Format:         volume.Format,
+		CoverAssetId:   volume.CoverAssetId,
+		SampleAssetIds: volume.SampleAssetIds,
+		Properties:     modelcoreutil.ToPropertyModels(volume.Properties),
+		Tags:           modelcoreutil.ToTagModels(volume.Tags),
+		SystemIds:      relationIDs(volume.Systems, func(s *vo.SystemVO) string { return s.ID }),
+		PublisherIds:   relationIDs(volume.Publishers, func(p *vo.PublisherVO) string { return p.ID }),
+		StudioIds:      relationIDs(volume.Studios, func(s *vo.StudioVO) string { return s.ID }),
+		LicenseIds:     relationIDs(volume.Licenses, func(l *vo.LicenseVO) string { return l.ID }),
+	}
+}
+
+// QueryVolumes lists the current (live) version of every volume matching params - the live
+// version's data is exactly today's flat volume shape, since exactly one version per record is
+// ever live at a time.
 func QueryVolumes(c context.Context, params apiutil.QueryParams) ([]*vo.VolumeVO, error) {
 	logging.Logger.Info("QueryVolumes", "c", c, "params", params)
 
 	span := tracing.BuildSpanWithParams(c, "volumes", "db-get-volumes", params)
-	logging.Logger.Debug("query volumes", "span", span)
+	defer span.End()
 
 	filter, sort, projection := apiutil.ConvertQueryParams(params)
+	filter = append(filter, bson.E{Key: "state", Value: string(models.VersionStateLive)})
 	logging.Logger.Debug("query volumes", "filter", filter, "sort", sort, "projection", projection)
-	models, err := database.Query[models.Volume]("volumes", filter, sort, projection, params.Start, params.Limit)
-	logging.Logger.Debug("got volumes", "models", models, "err", err)
-	span.End()
+
+	versions, err := database.Query[models.VolumeVersion](volumeVersionCollection, filter, sort, projection, params.Start, params.Limit)
 	if err != nil {
 		logging.Logger.Error(fmt.Sprintf("Error while querying database for Volumes: %+v", err))
 		return nil, err
 	}
 
-	vos := make([]*vo.VolumeVO, 0, len(models))
-	for _, model := range models {
-		logging.Logger.Debug("processing volume model", "model", model)
-		vos = append(vos, volumeModelToVO(c, model))
+	vos := make([]*vo.VolumeVO, 0, len(versions))
+	for _, version := range versions {
+		meta, err := getVolumeMeta(c, version.RecordID)
+		if err != nil {
+			logging.Logger.Error(fmt.Sprintf("No VolumeMeta found for VolumeVersion record %s: %s", version.RecordID, err.Error()))
+			continue
+		}
+		if meta == nil {
+			logging.Logger.Error(fmt.Sprintf("No VolumeMeta found for VolumeVersion record %s", version.RecordID))
+			continue
+		}
+		vos = append(vos, flattenVolume(c, meta, version))
 	}
 
 	logging.Logger.Debug("returning volume value objects", "vos", vos)

--- a/data/volume_migration.go
+++ b/data/volume_migration.go
@@ -1,0 +1,77 @@
+package data
+
+import (
+	"context"
+
+	"github.com/sweetrpg/catalog-objects.go/models"
+	"github.com/sweetrpg/common.go/logging"
+	"github.com/sweetrpg/mongodb.go/database"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+// MigrateVolumes backfills every existing "volumes" document (the pre-versioning flat model)
+// into a meta record plus a single live version, per design.md's Migration Plan. Idempotent -
+// a record that already has a meta record (recognized by the same ID) is left untouched, so
+// this is safe to re-run after a partial failure.
+func MigrateVolumes(c context.Context) (int, error) {
+	all, err := database.Query[models.Volume]("volumes", bson.D{}, nil, nil, 0, 0)
+	if err != nil {
+		logging.Logger.Error("MigrateVolumes: query existing volumes", "error", err)
+		return 0, err
+	}
+
+	migrated := 0
+	for _, v := range all {
+		existing, err := getVolumeMeta(c, v.ID)
+		if err != nil {
+			return migrated, err
+		}
+		if existing != nil {
+			continue
+		}
+
+		meta := models.VolumeMeta{
+			ID:             v.ID,
+			CurrentVersion: 1,
+			CreatedAt:      v.CreatedAt,
+			CreatedBy:      v.CreatedBy,
+			DeletedAt:      v.DeletedAt,
+			DeletedBy:      v.DeletedBy,
+		}
+		if _, err := database.Insert[models.VolumeMeta](volumeMetaCollection, meta); err != nil {
+			logging.Logger.Error("MigrateVolumes: insert meta", "id", v.ID, "error", err)
+			return migrated, err
+		}
+
+		version := models.VolumeVersion{
+			ID:             primitive.NewObjectID().Hex(),
+			RecordID:       v.ID,
+			Version:        1,
+			Title:          v.Title,
+			Description:    v.Description,
+			Notes:          v.Notes,
+			Format:         v.Format,
+			CoverAssetId:   v.CoverAssetId,
+			SampleAssetIds: v.SampleAssetIds,
+			SystemIds:      v.SystemIds,
+			PublisherIds:   v.PublisherIds,
+			StudioIds:      v.StudioIds,
+			LicenseIds:     v.LicenseIds,
+			Properties:     v.Properties,
+			Tags:           v.Tags,
+			State:          models.VersionStateLive,
+			BaseVersion:    nil,
+			SubmittedBy:    v.UpdatedBy,
+			SubmittedAt:    v.UpdatedAt,
+		}
+		if _, err := database.Insert[models.VolumeVersion](volumeVersionCollection, version); err != nil {
+			logging.Logger.Error("MigrateVolumes: insert version", "id", v.ID, "error", err)
+			return migrated, err
+		}
+
+		migrated++
+	}
+
+	return migrated, nil
+}

--- a/data/volume_migration_test.go
+++ b/data/volume_migration_test.go
@@ -1,0 +1,100 @@
+package data
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"github.com/sweetrpg/catalog-objects.go/models"
+	"github.com/sweetrpg/catalog-objects.go/vo"
+	"github.com/sweetrpg/common.go/logging"
+	modelcore "github.com/sweetrpg/model-core.go/models"
+	"github.com/sweetrpg/mongodb.go/constants"
+	"github.com/sweetrpg/mongodb.go/database"
+)
+
+type VolumeMigrationTestSuite struct {
+	suite.Suite
+}
+
+func (suite *VolumeMigrationTestSuite) SetupTest() {
+	_ = os.Setenv(constants.DB_URI, os.Getenv("TEST_DB_URI"))
+	logging.Init()
+	database.SetupDatabase()
+	assert.NoError(suite.T(), EnsureVolumeVersioningIndexes(suite.T().Context()))
+}
+
+func (suite *VolumeMigrationTestSuite) TestMigrateVolumesBackfillsMetaAndLiveVersion() {
+	legacy := models.Volume{
+		ID:          "legacy-volume-1",
+		Title:       "Legacy Volume",
+		Description: "Predates versioning",
+		Auditable: modelcore.Auditable{
+			CreatedAt: time.Now().Add(-48 * time.Hour),
+			CreatedBy: "auth0|original-creator",
+			UpdatedAt: time.Now().Add(-24 * time.Hour),
+			UpdatedBy: "auth0|last-editor",
+		},
+	}
+	_, err := database.Insert[models.Volume]("volumes", legacy)
+	assert.NoError(suite.T(), err)
+
+	migrated, err := MigrateVolumes(suite.T().Context())
+	assert.NoError(suite.T(), err)
+	assert.GreaterOrEqual(suite.T(), migrated, 1)
+
+	fetched, err := GetVolume(suite.T().Context(), legacy.ID)
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), fetched)
+	assert.Equal(suite.T(), "Legacy Volume", fetched.Title)
+	assert.Equal(suite.T(), "auth0|original-creator", fetched.CreatedBy)
+
+	version, err := GetVolumeVersion(suite.T().Context(), legacy.ID, 1)
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), version)
+	assert.Equal(suite.T(), models.VersionStateLive, models.VersionState(version.State))
+	assert.Nil(suite.T(), version.BaseVersion)
+}
+
+func (suite *VolumeMigrationTestSuite) TestMigrateVolumesIsIdempotent() {
+	legacy := models.Volume{ID: "legacy-volume-2", Title: "Legacy Volume Two"}
+	_, err := database.Insert[models.Volume]("volumes", legacy)
+	assert.NoError(suite.T(), err)
+
+	first, err := MigrateVolumes(suite.T().Context())
+	assert.NoError(suite.T(), err)
+	assert.GreaterOrEqual(suite.T(), first, 1)
+
+	second, err := MigrateVolumes(suite.T().Context())
+	assert.NoError(suite.T(), err)
+
+	versions, err := ListVolumeVersions(suite.T().Context(), legacy.ID)
+	assert.NoError(suite.T(), err)
+	assert.Len(suite.T(), versions, 1, "re-running the migration must not create a second version")
+	_ = second
+}
+
+func (suite *VolumeMigrationTestSuite) TestCreateSubmittedVolumeVersionPreservesHistoricalSubmission() {
+	id, err := AddVolume(suite.T().Context(), &vo.VolumeVO{Title: "Live Title"})
+	assert.NoError(suite.T(), err)
+
+	historicalSubmittedAt := time.Now().Add(-72 * time.Hour)
+	version, err := CreateSubmittedVolumeVersion(
+		suite.T().Context(), *id, &vo.VolumeVO{Title: "Proposed From Legacy System"},
+		"auth0|legacy-submitter", historicalSubmittedAt)
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), version)
+	assert.Equal(suite.T(), models.VersionStateSubmitted, models.VersionState(version.State))
+	assert.Equal(suite.T(), "auth0|legacy-submitter", version.SubmittedBy)
+	assert.WithinDuration(suite.T(), historicalSubmittedAt, version.SubmittedAt, time.Second)
+
+	fetched, err := GetVolume(suite.T().Context(), *id)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), "Live Title", fetched.Title, "a submitted version must not move the live record")
+}
+
+func TestVolumeMigrationTestSuite(t *testing.T) {
+	suite.Run(t, new(VolumeMigrationTestSuite))
+}

--- a/data/volume_test.go
+++ b/data/volume_test.go
@@ -23,6 +23,7 @@ func (suite *VolumeDataTestSuite) SetupTest() {
 	_ = os.Setenv(constants.DB_URI, os.Getenv("TEST_DB_URI"))
 	logging.Init()
 	database.SetupDatabase()
+	assert.NoError(suite.T(), EnsureVolumeVersioningIndexes(suite.T().Context()))
 
 	id, err := AddVolume(suite.T().Context(), &vo.VolumeVO{
 		Title:       "Test Volume",
@@ -71,7 +72,7 @@ func (suite *VolumeDataTestSuite) TestQueryVolumesSorted() {
 		Start: 0,
 		Limit: 10,
 		Sort: []apiutil.Sort{
-			{Field: "Title", Order: 1},
+			{Field: "title", Order: 1},
 		},
 	}
 	volumes, err := QueryVolumes(suite.T().Context(), params)
@@ -101,32 +102,60 @@ func (suite *VolumeDataTestSuite) TestQueryVolumesProjected() {
 	assert.NotEmpty(suite.T(), volumes)
 }
 
-func (suite *VolumeDataTestSuite) TestUpdateVolume() {
-	updated, err := UpdateVolume(suite.T().Context(), suite.seedVolumeID, &vo.VolumeVO{
+func (suite *VolumeDataTestSuite) TestQueryVolumesPaged() {
+	params := apiutil.QueryParams{
+		Limit: 10,
+		Start: 0,
+	}
+	volumes, err := QueryVolumes(suite.T().Context(), params)
+	assert.Nil(suite.T(), err)
+	assert.NotEmpty(suite.T(), volumes)
+}
+
+func (suite *VolumeDataTestSuite) TestUpdateVolumeLiveMovesCurrentVersion() {
+	version, err := UpdateVolume(suite.T().Context(), suite.seedVolumeID, &vo.VolumeVO{
 		Title:       "Updated Test Volume",
 		Description: "This volume was updated.",
-	})
+	}, models.VersionStateLive)
 	assert.NoError(suite.T(), err)
-	assert.NotNil(suite.T(), updated)
-	assert.Equal(suite.T(), "Updated Test Volume", updated.Title)
-	assert.Equal(suite.T(), "This volume was updated.", updated.Description)
+	assert.NotNil(suite.T(), version)
+	assert.Equal(suite.T(), models.VersionStateLive, models.VersionState(version.State))
+	assert.Equal(suite.T(), 2, version.Version)
 
 	fetched, err := GetVolume(suite.T().Context(), suite.seedVolumeID)
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), fetched)
 	assert.Equal(suite.T(), "Updated Test Volume", fetched.Title)
+
+	versions, err := ListVolumeVersions(suite.T().Context(), suite.seedVolumeID)
+	assert.NoError(suite.T(), err)
+	assert.Len(suite.T(), versions, 2)
+	assert.Equal(suite.T(), models.VersionStateArchived, models.VersionState(versions[1].State))
+}
+
+func (suite *VolumeDataTestSuite) TestUpdateVolumeSubmittedLeavesCurrentVersionUnchanged() {
+	version, err := UpdateVolume(suite.T().Context(), suite.seedVolumeID, &vo.VolumeVO{
+		Title: "Proposed Title",
+	}, models.VersionStateSubmitted)
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), version)
+	assert.Equal(suite.T(), models.VersionStateSubmitted, models.VersionState(version.State))
+
+	fetched, err := GetVolume(suite.T().Context(), suite.seedVolumeID)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), "Test Volume", fetched.Title)
 }
 
 func (suite *VolumeDataTestSuite) TestUpdateVolumeSetsCoverAndSampleAssetIds() {
-	updated, err := UpdateVolume(suite.T().Context(), suite.seedVolumeID, &vo.VolumeVO{
+	version, err := UpdateVolume(suite.T().Context(), suite.seedVolumeID, &vo.VolumeVO{
 		Title:          "Volume With Assets",
 		CoverAssetId:   "cover-abc",
 		SampleAssetIds: []string{"sample-1", "sample-2"},
-	})
+	}, models.VersionStateLive)
 	assert.NoError(suite.T(), err)
-	assert.NotNil(suite.T(), updated)
-	assert.Equal(suite.T(), "cover-abc", updated.CoverAssetId)
-	assert.Equal(suite.T(), []string{"sample-1", "sample-2"}, updated.SampleAssetIds)
+	assert.NotNil(suite.T(), version)
+	assert.Equal(suite.T(), "cover-abc", version.CoverAssetId)
+	assert.Equal(suite.T(), []string{"sample-1", "sample-2"}, version.SampleAssetIds)
 
 	fetched, err := GetVolume(suite.T().Context(), suite.seedVolumeID)
 	assert.NoError(suite.T(), err)
@@ -138,23 +167,24 @@ func (suite *VolumeDataTestSuite) TestUpdateVolumePreservesCreatedAudit() {
 	before, err := GetVolume(suite.T().Context(), suite.seedVolumeID)
 	assert.NoError(suite.T(), err)
 
-	updated, err := UpdateVolume(suite.T().Context(), suite.seedVolumeID, &vo.VolumeVO{
+	_, err = UpdateVolume(suite.T().Context(), suite.seedVolumeID, &vo.VolumeVO{
 		Title: "Another Update",
-	})
+	}, models.VersionStateLive)
 	assert.NoError(suite.T(), err)
-	assert.NotNil(suite.T(), updated)
-	assert.Equal(suite.T(), before.CreatedAt, updated.CreatedAt)
-	assert.True(suite.T(), updated.UpdatedAt.After(before.UpdatedAt) || updated.UpdatedAt.Equal(before.UpdatedAt))
+
+	after, err := GetVolume(suite.T().Context(), suite.seedVolumeID)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), before.CreatedAt, after.CreatedAt)
+	assert.True(suite.T(), after.UpdatedAt.After(before.UpdatedAt) || after.UpdatedAt.Equal(before.UpdatedAt))
 }
 
 func (suite *VolumeDataTestSuite) TestUpdateVolumeSetsFormat() {
-	updated, err := UpdateVolume(suite.T().Context(), suite.seedVolumeID, &vo.VolumeVO{
+	version, err := UpdateVolume(suite.T().Context(), suite.seedVolumeID, &vo.VolumeVO{
 		Title:  "Volume With Format",
 		Format: "hardcover",
-	})
+	}, models.VersionStateLive)
 	assert.NoError(suite.T(), err)
-	assert.NotNil(suite.T(), updated)
-	assert.Equal(suite.T(), "hardcover", updated.Format)
+	assert.Equal(suite.T(), "hardcover", version.Format)
 
 	fetched, err := GetVolume(suite.T().Context(), suite.seedVolumeID)
 	assert.NoError(suite.T(), err)
@@ -162,11 +192,11 @@ func (suite *VolumeDataTestSuite) TestUpdateVolumeSetsFormat() {
 }
 
 func (suite *VolumeDataTestSuite) TestUpdateVolumeNotFound() {
-	updated, err := UpdateVolume(suite.T().Context(), "000000000000000000000000", &vo.VolumeVO{
+	version, err := UpdateVolume(suite.T().Context(), "000000000000000000000000", &vo.VolumeVO{
 		Title: "Does Not Exist",
-	})
+	}, models.VersionStateLive)
 	assert.NoError(suite.T(), err)
-	assert.Nil(suite.T(), updated)
+	assert.Nil(suite.T(), version)
 }
 
 // TestUpdateVolumeWithPublisherRelationship guards against a regression: VolumeVO.Publishers
@@ -178,14 +208,11 @@ func (suite *VolumeDataTestSuite) TestUpdateVolumeWithPublisherRelationship() {
 	_, err := database.Insert("publishers", models.Publisher{ID: "pub-test-1", Name: "Test Publisher"})
 	assert.NoError(suite.T(), err)
 
-	updated, err := UpdateVolume(suite.T().Context(), suite.seedVolumeID, &vo.VolumeVO{
+	_, err = UpdateVolume(suite.T().Context(), suite.seedVolumeID, &vo.VolumeVO{
 		Title:      "Volume With Publisher",
 		Publishers: []*vo.PublisherVO{{ID: "pub-test-1"}},
-	})
+	}, models.VersionStateLive)
 	assert.NoError(suite.T(), err)
-	assert.NotNil(suite.T(), updated)
-	assert.Len(suite.T(), updated.Publishers, 1)
-	assert.Equal(suite.T(), "pub-test-1", updated.Publishers[0].ID)
 
 	fetched, err := GetVolume(suite.T().Context(), suite.seedVolumeID)
 	assert.NoError(suite.T(), err)
@@ -195,14 +222,127 @@ func (suite *VolumeDataTestSuite) TestUpdateVolumeWithPublisherRelationship() {
 	assert.Equal(suite.T(), "Test Publisher", fetched.Publishers[0].Name)
 }
 
-func (suite *VolumeDataTestSuite) TestQueryVolumesPaged() {
-	params := apiutil.QueryParams{
-		Limit: 10,
-		Start: 0,
-	}
-	volumes, err := QueryVolumes(suite.T().Context(), params)
-	assert.Nil(suite.T(), err)
-	assert.NotEmpty(suite.T(), volumes)
+func (suite *VolumeDataTestSuite) TestListVolumeVersions() {
+	_, err := UpdateVolume(suite.T().Context(), suite.seedVolumeID, &vo.VolumeVO{Title: "V2"}, models.VersionStateLive)
+	assert.NoError(suite.T(), err)
+
+	versions, err := ListVolumeVersions(suite.T().Context(), suite.seedVolumeID)
+	assert.NoError(suite.T(), err)
+	assert.Len(suite.T(), versions, 2)
+	assert.Equal(suite.T(), 2, versions[0].Version)
+	assert.Equal(suite.T(), 1, versions[1].Version)
+}
+
+func (suite *VolumeDataTestSuite) TestGetVolumeVersion() {
+	version, err := GetVolumeVersion(suite.T().Context(), suite.seedVolumeID, 1)
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), version)
+	assert.Equal(suite.T(), "Test Volume", version.Title)
+}
+
+func (suite *VolumeDataTestSuite) TestGetVolumeVersionNotFound() {
+	version, err := GetVolumeVersion(suite.T().Context(), suite.seedVolumeID, 99)
+	assert.NoError(suite.T(), err)
+	assert.Nil(suite.T(), version)
+}
+
+func (suite *VolumeDataTestSuite) TestAcceptVolumeVersionFullCleanPromotesSubmission() {
+	submitted, err := UpdateVolume(suite.T().Context(), suite.seedVolumeID, &vo.VolumeVO{
+		Title:       "Submitted Title",
+		Description: "This is a test volume.",
+	}, models.VersionStateSubmitted)
+	assert.NoError(suite.T(), err)
+
+	accepted, conflicts, err := AcceptVolumeVersion(suite.T().Context(), suite.seedVolumeID, submitted.Version, nil, "editor-1", nil)
+	assert.NoError(suite.T(), err)
+	assert.Empty(suite.T(), conflicts)
+	assert.Equal(suite.T(), submitted.Version, accepted.Version)
+	assert.Equal(suite.T(), models.VersionStateLive, models.VersionState(accepted.State))
+
+	fetched, err := GetVolume(suite.T().Context(), suite.seedVolumeID)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), "Submitted Title", fetched.Title)
+}
+
+func (suite *VolumeDataTestSuite) TestAcceptVolumeVersionSelectedFieldsDerivesNewVersion() {
+	submitted, err := UpdateVolume(suite.T().Context(), suite.seedVolumeID, &vo.VolumeVO{
+		Title:       "Submitted Title",
+		Description: "Submitted description.",
+	}, models.VersionStateSubmitted)
+	assert.NoError(suite.T(), err)
+
+	accepted, conflicts, err := AcceptVolumeVersion(suite.T().Context(), suite.seedVolumeID, submitted.Version, []string{"title"}, "editor-1", nil)
+	assert.NoError(suite.T(), err)
+	assert.Empty(suite.T(), conflicts)
+	assert.NotEqual(suite.T(), submitted.Version, accepted.Version)
+	assert.Equal(suite.T(), "Submitted Title", accepted.Title)
+	assert.Equal(suite.T(), "This is a test volume.", accepted.Description)
+
+	original, err := GetVolumeVersion(suite.T().Context(), suite.seedVolumeID, submitted.Version)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), models.VersionStatePartiallyAccepted, models.VersionState(original.State))
+	assert.NotNil(suite.T(), original.ResultingVersion)
+	assert.Equal(suite.T(), accepted.Version, *original.ResultingVersion)
+}
+
+func (suite *VolumeDataTestSuite) TestAcceptVolumeVersionConflictExcludesDriftedField() {
+	submitted, err := UpdateVolume(suite.T().Context(), suite.seedVolumeID, &vo.VolumeVO{
+		Title:       "Submitted Title",
+		Description: "Submitted description.",
+	}, models.VersionStateSubmitted)
+	assert.NoError(suite.T(), err)
+
+	// A different edit lands on the live record after submission, drifting Description.
+	_, err = UpdateVolume(suite.T().Context(), suite.seedVolumeID, &vo.VolumeVO{
+		Title:       "Test Volume",
+		Description: "Someone else changed this first.",
+	}, models.VersionStateLive)
+	assert.NoError(suite.T(), err)
+
+	accepted, conflicts, err := AcceptVolumeVersion(suite.T().Context(), suite.seedVolumeID, submitted.Version, nil, "editor-1", nil)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), []string{"description"}, conflicts)
+	assert.Equal(suite.T(), "Submitted Title", accepted.Title)
+	assert.Equal(suite.T(), "Someone else changed this first.", accepted.Description)
+}
+
+func (suite *VolumeDataTestSuite) TestRejectVolumeVersion() {
+	submitted, err := UpdateVolume(suite.T().Context(), suite.seedVolumeID, &vo.VolumeVO{
+		Title: "Rejected Title",
+	}, models.VersionStateSubmitted)
+	assert.NoError(suite.T(), err)
+
+	note := "not a good fit"
+	err = RejectVolumeVersion(suite.T().Context(), suite.seedVolumeID, submitted.Version, "editor-1", &note)
+	assert.NoError(suite.T(), err)
+
+	rejected, err := GetVolumeVersion(suite.T().Context(), suite.seedVolumeID, submitted.Version)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), models.VersionStateRejected, models.VersionState(rejected.State))
+	assert.Equal(suite.T(), &note, rejected.ReviewNote)
+
+	fetched, err := GetVolume(suite.T().Context(), suite.seedVolumeID)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), "Test Volume", fetched.Title)
+}
+
+func (suite *VolumeDataTestSuite) TestSetCurrentVolumeVersionRollback() {
+	_, err := UpdateVolume(suite.T().Context(), suite.seedVolumeID, &vo.VolumeVO{
+		Title: "V2 Title",
+	}, models.VersionStateLive)
+	assert.NoError(suite.T(), err)
+
+	restored, err := SetCurrentVolumeVersion(suite.T().Context(), suite.seedVolumeID, 1)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), models.VersionStateLive, models.VersionState(restored.State))
+
+	fetched, err := GetVolume(suite.T().Context(), suite.seedVolumeID)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), "Test Volume", fetched.Title)
+
+	v2, err := GetVolumeVersion(suite.T().Context(), suite.seedVolumeID, 2)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), models.VersionStateArchived, models.VersionState(v2.State))
 }
 
 func TestDbTestSuite(t *testing.T) {

--- a/data/volume_versioning.go
+++ b/data/volume_versioning.go
@@ -1,0 +1,417 @@
+package data
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sort"
+	"time"
+
+	"github.com/sweetrpg/catalog-objects.go/models"
+	"github.com/sweetrpg/catalog-objects.go/vo"
+	"github.com/sweetrpg/common.go/logging"
+	modelcore "github.com/sweetrpg/model-core.go/models"
+	"github.com/sweetrpg/mongodb.go/database"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+const (
+	volumeMetaCollection    = "volumes_meta"
+	volumeVersionCollection = "volumes_versions"
+)
+
+// EnsureVolumeVersioningIndexes creates the indexes volume version queries rely on: a unique
+// (record_id, version) index so a version number can never be reused for a record, and a
+// (record_id, state) index for the pending-submission lookup. Safe to call on every startup.
+func EnsureVolumeVersioningIndexes(ctx context.Context) error {
+	_, err := database.Db.Collection(volumeVersionCollection).Indexes().CreateOne(ctx, mongo.IndexModel{
+		Keys:    bson.D{{Key: "record_id", Value: 1}, {Key: "version", Value: 1}},
+		Options: options.Index().SetUnique(true),
+	})
+	if err != nil {
+		return fmt.Errorf("volumes: create record_id+version index: %w", err)
+	}
+
+	_, err = database.Db.Collection(volumeVersionCollection).Indexes().CreateOne(ctx, mongo.IndexModel{
+		Keys: bson.D{{Key: "record_id", Value: 1}, {Key: "state", Value: 1}},
+	})
+	if err != nil {
+		return fmt.Errorf("volumes: create record_id+state index: %w", err)
+	}
+
+	return nil
+}
+
+func getVolumeMeta(c context.Context, id string) (*models.VolumeMeta, error) {
+	results, err := database.Query[models.VolumeMeta](volumeMetaCollection, bson.D{{Key: "_id", Value: id}}, nil, nil, 0, 1)
+	if err != nil {
+		return nil, err
+	}
+	if len(results) == 0 {
+		return nil, nil
+	}
+	return results[0], nil
+}
+
+func getVolumeVersion(c context.Context, recordID string, version int) (*models.VolumeVersion, error) {
+	filter := bson.D{{Key: "record_id", Value: recordID}, {Key: "version", Value: version}}
+	results, err := database.Query[models.VolumeVersion](volumeVersionCollection, filter, nil, nil, 0, 1)
+	if err != nil {
+		return nil, err
+	}
+	if len(results) == 0 {
+		return nil, nil
+	}
+	return results[0], nil
+}
+
+func nextVolumeVersionNumber(c context.Context, recordID string) (int, error) {
+	filter := bson.D{{Key: "record_id", Value: recordID}}
+	sortOrder := bson.D{{Key: "version", Value: -1}}
+	results, err := database.Query[models.VolumeVersion](volumeVersionCollection, filter, sortOrder, nil, 0, 1)
+	if err != nil {
+		return 0, err
+	}
+	if len(results) == 0 {
+		return 1, nil
+	}
+	return results[0].Version + 1, nil
+}
+
+func setVolumeVersionState(c context.Context, recordID string, version int, fields bson.D) error {
+	filter := bson.D{{Key: "record_id", Value: recordID}, {Key: "version", Value: version}}
+	_, err := database.Db.Collection(volumeVersionCollection).UpdateOne(c, filter, bson.D{{Key: "$set", Value: fields}})
+	return err
+}
+
+func archiveVolumeVersion(c context.Context, recordID string, version int) error {
+	return setVolumeVersionState(c, recordID, version, bson.D{{Key: "state", Value: string(models.VersionStateArchived)}})
+}
+
+func setVolumeMetaCurrentVersion(c context.Context, recordID string, version int) error {
+	_, err := database.Db.Collection(volumeMetaCollection).UpdateOne(
+		c,
+		bson.D{{Key: "_id", Value: recordID}},
+		bson.D{{Key: "$set", Value: bson.D{{Key: "current_version", Value: version}}}},
+	)
+	return err
+}
+
+// ListVolumeVersions returns every version of a volume, newest first.
+func ListVolumeVersions(c context.Context, id string) ([]*vo.VolumeVersionVO, error) {
+	filter := bson.D{{Key: "record_id", Value: id}}
+	sortOrder := bson.D{{Key: "version", Value: -1}}
+	versions, err := database.Query[models.VolumeVersion](volumeVersionCollection, filter, sortOrder, nil, 0, 0)
+	if err != nil {
+		logging.Logger.Error(fmt.Sprintf("Error while querying database for VolumeVersions: %+v", err))
+		return nil, err
+	}
+
+	vos := make([]*vo.VolumeVersionVO, 0, len(versions))
+	for _, version := range versions {
+		vos = append(vos, volumeVersionModelToVO(c, version))
+	}
+	return vos, nil
+}
+
+// GetVolumeVersion returns one version's full snapshot, regardless of whether it's current.
+func GetVolumeVersion(c context.Context, id string, version int) (*vo.VolumeVersionVO, error) {
+	result, err := getVolumeVersion(c, id, version)
+	if err != nil {
+		logging.Logger.Error(fmt.Sprintf("Error while querying database for VolumeVersion: %+v", err))
+		return nil, err
+	}
+	if result == nil {
+		return nil, nil
+	}
+	return volumeVersionModelToVO(c, result), nil
+}
+
+// volumeVersionSubstantiveFields are the fields a submission can change and a review can
+// selectively accept - everything on VolumeVersion except its version-lifecycle bookkeeping.
+var volumeVersionSubstantiveFields = []string{
+	"title", "description", "notes", "format", "cover_asset_id", "sample_asset_ids",
+	"system_ids", "publisher_ids", "studio_ids", "license_ids", "properties", "tags",
+}
+
+func volumeVersionFieldValue(v *models.VolumeVersion, field string) any {
+	switch field {
+	case "title":
+		return v.Title
+	case "description":
+		return v.Description
+	case "notes":
+		return v.Notes
+	case "format":
+		return v.Format
+	case "cover_asset_id":
+		return v.CoverAssetId
+	case "sample_asset_ids":
+		return v.SampleAssetIds
+	case "system_ids":
+		return v.SystemIds
+	case "publisher_ids":
+		return v.PublisherIds
+	case "studio_ids":
+		return v.StudioIds
+	case "license_ids":
+		return v.LicenseIds
+	case "properties":
+		return v.Properties
+	case "tags":
+		return v.Tags
+	default:
+		return nil
+	}
+}
+
+func setVolumeVersionFieldValue(v *models.VolumeVersion, field string, value any) {
+	switch field {
+	case "title":
+		v.Title = value.(string)
+	case "description":
+		v.Description = value.(string)
+	case "notes":
+		v.Notes = value.(string)
+	case "format":
+		v.Format = value.(string)
+	case "cover_asset_id":
+		v.CoverAssetId = value.(string)
+	case "sample_asset_ids":
+		v.SampleAssetIds = value.([]string)
+	case "system_ids":
+		v.SystemIds = value.([]string)
+	case "publisher_ids":
+		v.PublisherIds = value.([]string)
+	case "studio_ids":
+		v.StudioIds = value.([]string)
+	case "license_ids":
+		v.LicenseIds = value.([]string)
+	case "properties":
+		v.Properties = value.([]modelcore.Property)
+	case "tags":
+		v.Tags = value.([]modelcore.Tag)
+	}
+}
+
+// volumeVersionChangedFields returns the substantive fields where submitted differs from base.
+func volumeVersionChangedFields(submitted, base *models.VolumeVersion) []string {
+	var changed []string
+	for _, field := range volumeVersionSubstantiveFields {
+		if !reflect.DeepEqual(volumeVersionFieldValue(submitted, field), volumeVersionFieldValue(base, field)) {
+			changed = append(changed, field)
+		}
+	}
+	return changed
+}
+
+func intersectFields(fields, selected []string) []string {
+	selectedSet := make(map[string]bool, len(selected))
+	for _, f := range selected {
+		selectedSet[f] = true
+	}
+	var out []string
+	for _, f := range fields {
+		if selectedSet[f] {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// AcceptVolumeVersion reviews a submitted version. selectedFields == nil accepts every field the
+// submission changed (full accept); a non-nil slice accepts only that subset. If the submission's
+// baseVersion no longer matches the record's actual current version, a field being accepted whose
+// actual-current value has itself diverged from baseVersion is excluded as a conflict rather than
+// applied - reported back via the returned conflicts slice.
+//
+// A clean full accept (no drift, no conflicts) promotes the submitted version itself to live. Any
+// other outcome (a selected-fields accept, or a full accept with conflicts excluded) derives a new
+// version from the actual current version with only the accepted fields overlaid, promotes that
+// derived version to live, and marks the submitted version partially_accepted, referencing it.
+func AcceptVolumeVersion(c context.Context, id string, version int, selectedFields []string, reviewedBy string, reviewNote *string) (*vo.VolumeVersionVO, []string, error) {
+	submitted, err := getVolumeVersion(c, id, version)
+	if err != nil {
+		return nil, nil, err
+	}
+	if submitted == nil {
+		return nil, nil, fmt.Errorf("volume %s: version %d not found", id, version)
+	}
+	if submitted.State != models.VersionStateSubmitted {
+		return nil, nil, fmt.Errorf("volume %s: version %d is not submitted (state: %s)", id, version, submitted.State)
+	}
+	if submitted.BaseVersion == nil {
+		return nil, nil, fmt.Errorf("volume %s: version %d has no base version to review against", id, version)
+	}
+
+	meta, err := getVolumeMeta(c, id)
+	if err != nil {
+		return nil, nil, err
+	}
+	if meta == nil {
+		return nil, nil, fmt.Errorf("volume %s: meta record not found", id)
+	}
+
+	current, err := getVolumeVersion(c, id, meta.CurrentVersion)
+	if err != nil {
+		return nil, nil, err
+	}
+	if current == nil {
+		return nil, nil, fmt.Errorf("volume %s: current version %d not found", id, meta.CurrentVersion)
+	}
+
+	now := time.Now()
+
+	if selectedFields == nil && *submitted.BaseVersion == meta.CurrentVersion {
+		if err := archiveVolumeVersion(c, id, meta.CurrentVersion); err != nil {
+			return nil, nil, err
+		}
+		submitted.State = models.VersionStateLive
+		submitted.ReviewedBy = &reviewedBy
+		submitted.ReviewedAt = &now
+		submitted.ReviewNote = reviewNote
+		if err := setVolumeVersionState(c, id, version, bson.D{
+			{Key: "state", Value: string(models.VersionStateLive)},
+			{Key: "reviewed_by", Value: reviewedBy},
+			{Key: "reviewed_at", Value: now},
+			{Key: "review_note", Value: reviewNote},
+		}); err != nil {
+			return nil, nil, err
+		}
+		if err := setVolumeMetaCurrentVersion(c, id, version); err != nil {
+			return nil, nil, err
+		}
+		return volumeVersionModelToVO(c, submitted), nil, nil
+	}
+
+	baseVersion, err := getVolumeVersion(c, id, *submitted.BaseVersion)
+	if err != nil {
+		return nil, nil, err
+	}
+	if baseVersion == nil {
+		return nil, nil, fmt.Errorf("volume %s: base version %d not found", id, *submitted.BaseVersion)
+	}
+
+	changed := volumeVersionChangedFields(submitted, baseVersion)
+	target := changed
+	if selectedFields != nil {
+		target = intersectFields(changed, selectedFields)
+	}
+	sort.Strings(target)
+
+	derived := *current
+	var conflicts []string
+	var accepted []string
+	for _, field := range target {
+		if !reflect.DeepEqual(volumeVersionFieldValue(current, field), volumeVersionFieldValue(baseVersion, field)) {
+			conflicts = append(conflicts, field)
+			continue
+		}
+		setVolumeVersionFieldValue(&derived, field, volumeVersionFieldValue(submitted, field))
+		accepted = append(accepted, field)
+	}
+
+	nextVersion, err := nextVolumeVersionNumber(c, id)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	derived.ID = primitive.NewObjectID().Hex()
+	derived.RecordID = id
+	derived.Version = nextVersion
+	derived.State = models.VersionStateLive
+	derived.BaseVersion = &meta.CurrentVersion
+	derived.SubmittedBy = submitted.SubmittedBy
+	derived.SubmittedAt = now
+	derived.ReviewedBy = &reviewedBy
+	derived.ReviewedAt = &now
+	derived.ReviewNote = reviewNote
+	derived.ResultingVersion = nil
+
+	if _, err := database.Insert[models.VolumeVersion](volumeVersionCollection, derived); err != nil {
+		return nil, nil, err
+	}
+	if err := archiveVolumeVersion(c, id, meta.CurrentVersion); err != nil {
+		return nil, nil, err
+	}
+	if err := setVolumeMetaCurrentVersion(c, id, nextVersion); err != nil {
+		return nil, nil, err
+	}
+	if err := setVolumeVersionState(c, id, version, bson.D{
+		{Key: "state", Value: string(models.VersionStatePartiallyAccepted)},
+		{Key: "reviewed_by", Value: reviewedBy},
+		{Key: "reviewed_at", Value: now},
+		{Key: "review_note", Value: reviewNote},
+		{Key: "resulting_version", Value: nextVersion},
+	}); err != nil {
+		return nil, nil, err
+	}
+
+	logging.Logger.Info("AcceptVolumeVersion: derived version", "id", id, "version", nextVersion, "accepted", accepted, "conflicts", conflicts)
+
+	return volumeVersionModelToVO(c, &derived), conflicts, nil
+}
+
+// RejectVolumeVersion marks a submitted version rejected, with an optional note. The record's
+// current-version pointer is unchanged.
+func RejectVolumeVersion(c context.Context, id string, version int, reviewedBy string, reviewNote *string) error {
+	submitted, err := getVolumeVersion(c, id, version)
+	if err != nil {
+		return err
+	}
+	if submitted == nil {
+		return fmt.Errorf("volume %s: version %d not found", id, version)
+	}
+	if submitted.State != models.VersionStateSubmitted {
+		return fmt.Errorf("volume %s: version %d is not submitted (state: %s)", id, version, submitted.State)
+	}
+
+	now := time.Now()
+	return setVolumeVersionState(c, id, version, bson.D{
+		{Key: "state", Value: string(models.VersionStateRejected)},
+		{Key: "reviewed_by", Value: reviewedBy},
+		{Key: "reviewed_at", Value: now},
+		{Key: "review_note", Value: reviewNote},
+	})
+}
+
+// SetCurrentVolumeVersion rolls a record back (or forward) to an arbitrary existing version,
+// independent of the submit/review flow - marking that version live and archiving whichever
+// version was previously current.
+func SetCurrentVolumeVersion(c context.Context, id string, version int) (*vo.VolumeVersionVO, error) {
+	meta, err := getVolumeMeta(c, id)
+	if err != nil {
+		return nil, err
+	}
+	if meta == nil {
+		return nil, nil
+	}
+
+	target, err := getVolumeVersion(c, id, version)
+	if err != nil {
+		return nil, err
+	}
+	if target == nil {
+		return nil, fmt.Errorf("volume %s: version %d not found", id, version)
+	}
+
+	if version == meta.CurrentVersion {
+		return volumeVersionModelToVO(c, target), nil
+	}
+
+	if err := archiveVolumeVersion(c, id, meta.CurrentVersion); err != nil {
+		return nil, err
+	}
+	if err := setVolumeVersionState(c, id, version, bson.D{{Key: "state", Value: string(models.VersionStateLive)}}); err != nil {
+		return nil, err
+	}
+	if err := setVolumeMetaCurrentVersion(c, id, version); err != nil {
+		return nil, err
+	}
+
+	target.State = models.VersionStateLive
+	return volumeVersionModelToVO(c, target), nil
+}

--- a/go.mod
+++ b/go.mod
@@ -49,3 +49,5 @@ require (
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/sweetrpg/catalog-objects.go => ../catalog-objects/go


### PR DESCRIPTION
## Summary
Task group 2 of `catalog-entity-versioning`: GetVolume/QueryVolumes/AddVolume/UpdateVolume now
read/write `volumes_meta` + `volumes_versions` instead of mutating a single live document.
Adds ListVolumeVersions, GetVolumeVersion, AcceptVolumeVersion (full and selected-fields accept,
including the drifted-baseVersion conflict path), RejectVolumeVersion, and
SetCurrentVolumeVersion (rollback).

`UpdateVolume`'s signature changed - it now takes a caller-determined `VersionState` and returns
the created version rather than mutating in place.

Depends on sweetrpg/catalog-objects.go#56 (temporary `replace` directive in go.mod until that
merges and releases).

Part of sweetrpg/platform#39.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` clean
- [x] `go test ./...` - all pass, including new conflict-exclusion and
      partial-accept-derives-a-new-version cases