### PR TITLE
Convert publisher/studio/license website to/from the new string VO field

### DIFF
--- a/data/entity_versioning.go
+++ b/data/entity_versioning.go
@@ -3,6 +3,7 @@ package data
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"reflect"
 	"sort"
 	"time"
@@ -15,6 +16,17 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
+
+// parseWebsite best-effort parses a VO's plain-string website into the url.URL the models layer
+// still stores (Mongo bson round-trips url.URL fine - only the JSON:API wire format needed the
+// plain-string fix). An unparseable or empty string yields the zero value, matching the
+// server-layer field accessors' same silent-skip-on-parse-error behavior.
+func parseWebsite(s string) url.URL {
+	if u, err := url.Parse(s); err == nil && u != nil {
+		return *u
+	}
+	return url.URL{}
+}
 
 // entityFieldAccessor reads/writes one substantive field on a version record - the version-model
 // counterpart of server/entity_patch.go's entityFieldAccessor, used here for the accept-selected

--- a/data/license_versioning.go
+++ b/data/license_versioning.go
@@ -52,7 +52,7 @@ func licenseVersionToVO(version *models.LicenseVersion) *vo.LicenseVersionVO {
 	return &vo.LicenseVersionVO{
 		ID: version.ID, RecordID: version.RecordID, Version: version.Version,
 		Title: version.Title, ShortTitle: version.ShortTitle, LicenseVer: version.LicenseVer,
-		Deed: version.Deed, LegalCode: version.LegalCode, Website: version.Website,
+		Deed: version.Deed, LegalCode: version.LegalCode, Website: version.Website.String(),
 		Status: version.Status, Availability: version.Availability, Notes: version.Notes,
 		Properties: modelcoreutil.FromPropertyModels(version.Properties),
 		Tags:       modelcoreutil.FromTagModels(version.Tags),
@@ -68,7 +68,7 @@ func licenseVersionToVO(version *models.LicenseVersion) *vo.LicenseVersionVO {
 func licenseVersionFields(license *vo.LicenseVO) models.LicenseVersion {
 	return models.LicenseVersion{
 		Title: license.Title, ShortTitle: license.ShortTitle, LicenseVer: license.Version,
-		Deed: license.Deed, LegalCode: license.LegalCode, Website: license.Website,
+		Deed: license.Deed, LegalCode: license.LegalCode, Website: parseWebsite(license.Website),
 		Status: license.Status, Availability: license.Availability, Notes: license.Notes,
 		Properties: modelcoreutil.ToPropertyModels(license.Properties),
 		Tags:       modelcoreutil.ToTagModels(license.Tags),
@@ -78,7 +78,7 @@ func licenseVersionFields(license *vo.LicenseVO) models.LicenseVersion {
 func flattenLicense(meta *models.EntityMeta, version *models.LicenseVersion) *vo.LicenseVO {
 	return &vo.LicenseVO{
 		ID: meta.ID, Title: version.Title, ShortTitle: version.ShortTitle, Version: version.LicenseVer,
-		Deed: version.Deed, LegalCode: version.LegalCode, Website: version.Website,
+		Deed: version.Deed, LegalCode: version.LegalCode, Website: version.Website.String(),
 		Status: version.Status, Availability: version.Availability, Notes: version.Notes,
 		Properties: modelcoreutil.FromPropertyModels(version.Properties),
 		Tags:       modelcoreutil.FromTagModels(version.Tags),

--- a/data/publisher_test.go
+++ b/data/publisher_test.go
@@ -148,6 +148,20 @@ func (suite *PublisherDataTestSuite) TestSetCurrentPublisherVersion() {
 	assert.Equal(suite.T(), string(models.VersionStateLive), string(refetched.State))
 }
 
+func (suite *PublisherDataTestSuite) TestWebsiteRoundTripsAsPlainString() {
+	updated, err := UpdatePublisher(suite.T().Context(), suite.seedPublisherID, &vo.PublisherVO{
+		Name: "Test Publisher", Website: "https://example.com/kobold",
+	}, models.VersionStateLive)
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), updated)
+	assert.Equal(suite.T(), "https://example.com/kobold", updated.Website)
+
+	fetched, err := GetPublisher(suite.T().Context(), suite.seedPublisherID)
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), fetched)
+	assert.Equal(suite.T(), "https://example.com/kobold", fetched.Website)
+}
+
 func TestPublisherDbTestSuite(t *testing.T) {
 	suite.Run(t, new(PublisherDataTestSuite))
 }

--- a/data/publisher_versioning.go
+++ b/data/publisher_versioning.go
@@ -46,7 +46,7 @@ func EnsurePublisherVersioningIndexes(c context.Context) error {
 func publisherVersionToVO(version *models.PublisherVersion) *vo.PublisherVersionVO {
 	return &vo.PublisherVersionVO{
 		ID: version.ID, RecordID: version.RecordID, Version: version.Version,
-		Name: version.Name, Address: version.Address, Website: version.Website, Notes: version.Notes,
+		Name: version.Name, Address: version.Address, Website: version.Website.String(), Notes: version.Notes,
 		Properties: modelcoreutil.FromPropertyModels(version.Properties),
 		Tags:       modelcoreutil.FromTagModels(version.Tags),
 		VersionLifecycleVO: vo.VersionLifecycleVO{
@@ -60,7 +60,7 @@ func publisherVersionToVO(version *models.PublisherVersion) *vo.PublisherVersion
 
 func publisherVersionFields(publisher *vo.PublisherVO) models.PublisherVersion {
 	return models.PublisherVersion{
-		Name: publisher.Name, Address: publisher.Address, Website: publisher.Website, Notes: publisher.Notes,
+		Name: publisher.Name, Address: publisher.Address, Website: parseWebsite(publisher.Website), Notes: publisher.Notes,
 		Properties: modelcoreutil.ToPropertyModels(publisher.Properties),
 		Tags:       modelcoreutil.ToTagModels(publisher.Tags),
 	}
@@ -68,7 +68,7 @@ func publisherVersionFields(publisher *vo.PublisherVO) models.PublisherVersion {
 
 func flattenPublisher(meta *models.EntityMeta, version *models.PublisherVersion) *vo.PublisherVO {
 	return &vo.PublisherVO{
-		ID: meta.ID, Name: version.Name, Address: version.Address, Website: version.Website, Notes: version.Notes,
+		ID: meta.ID, Name: version.Name, Address: version.Address, Website: version.Website.String(), Notes: version.Notes,
 		Properties: modelcoreutil.FromPropertyModels(version.Properties),
 		Tags:       modelcoreutil.FromTagModels(version.Tags),
 		AuditableVO: modelcorevo.AuditableVO{

--- a/data/studio_versioning.go
+++ b/data/studio_versioning.go
@@ -45,7 +45,7 @@ func EnsureStudioVersioningIndexes(c context.Context) error {
 func studioVersionToVO(version *models.StudioVersion) *vo.StudioVersionVO {
 	return &vo.StudioVersionVO{
 		ID: version.ID, RecordID: version.RecordID, Version: version.Version,
-		Name: version.Name, Website: version.Website, Notes: version.Notes,
+		Name: version.Name, Website: version.Website.String(), Notes: version.Notes,
 		Properties: modelcoreutil.FromPropertyModels(version.Properties),
 		Tags:       modelcoreutil.FromTagModels(version.Tags),
 		VersionLifecycleVO: vo.VersionLifecycleVO{
@@ -59,7 +59,7 @@ func studioVersionToVO(version *models.StudioVersion) *vo.StudioVersionVO {
 
 func studioVersionFields(studio *vo.StudioVO) models.StudioVersion {
 	return models.StudioVersion{
-		Name: studio.Name, Website: studio.Website, Notes: studio.Notes,
+		Name: studio.Name, Website: parseWebsite(studio.Website), Notes: studio.Notes,
 		Properties: modelcoreutil.ToPropertyModels(studio.Properties),
 		Tags:       modelcoreutil.ToTagModels(studio.Tags),
 	}
@@ -67,7 +67,7 @@ func studioVersionFields(studio *vo.StudioVO) models.StudioVersion {
 
 func flattenStudio(meta *models.EntityMeta, version *models.StudioVersion) *vo.StudioVO {
 	return &vo.StudioVO{
-		ID: meta.ID, Name: version.Name, Website: version.Website, Notes: version.Notes,
+		ID: meta.ID, Name: version.Name, Website: version.Website.String(), Notes: version.Notes,
 		Properties: modelcoreutil.FromPropertyModels(version.Properties),
 		Tags:       modelcoreutil.FromTagModels(version.Tags),
 		AuditableVO: modelcorevo.AuditableVO{

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.5
 require (
 	github.com/stretchr/testify v1.11.1
 	github.com/sweetrpg/api-core.go v0.0.436
-	github.com/sweetrpg/catalog-objects.go v0.4.0
+	github.com/sweetrpg/catalog-objects.go v0.4.1
 	github.com/sweetrpg/common.go v0.0.16
 	github.com/sweetrpg/model-core.go v0.0.173
 	github.com/sweetrpg/mongodb.go v0.0.193

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/sweetrpg/api-core.go v0.0.436 h1:sCMdy9f82Y3RMtlQOnYljQ3dFjaLR3qvgyNJmME9nq0=
 github.com/sweetrpg/api-core.go v0.0.436/go.mod h1:hWjWppLsrQ8R+u3FD8NjJo+uuxkEeGJx2DOlQO0XGm4=
-github.com/sweetrpg/catalog-objects.go v0.4.0 h1:6BD5IqXcqBXpIfJx13+iX2GeOrIAt83nTemvxyBt0iU=
-github.com/sweetrpg/catalog-objects.go v0.4.0/go.mod h1:94LMLsDebNMb629Nv+FHkKq+FI6H8CeCbeDl9RWs2O0=
+github.com/sweetrpg/catalog-objects.go v0.4.1 h1:nCWdCXptAeIb99BAiK5w+OpDu4ZXstqaIzvQCka3CVI=
+github.com/sweetrpg/catalog-objects.go v0.4.1/go.mod h1:94LMLsDebNMb629Nv+FHkKq+FI6H8CeCbeDl9RWs2O0=
 github.com/sweetrpg/common.go v0.0.16 h1:XT8PwUXz0BOMIITXLjw3G6rEjjRUEs0Xs4+R9o2fVBk=
 github.com/sweetrpg/common.go v0.0.16/go.mod h1:PVpjDIeB/bZYJZk5fc8whuqVJE8K5k/DsO3o+aZFEcE=
 github.com/sweetrpg/model-core.go v0.0.173 h1:mIZ4z0ETkCH7I3Az0jwTFOyh66OTm7Z4/f0Rx/w+5Fk=


### PR DESCRIPTION
Follows sweetrpg/catalog-objects.go#61 (v0.4.1): PublisherVO/StudioVO/LicenseVO.Website changed
from url.URL to string, since url.URL has no MarshalJSON and was serializing as its internal
struct fields over JSON:API instead of a URL string - breaking every non-Go client.

The Mongo-layer models still store url.URL (bson round-trips it fine). Added parseWebsite() in
entity_versioning.go to convert string->url.URL when building a version to write, and use
.String() when flattening a stored version back into a VO. Added a round-trip test.

Part of sweetrpg/platform#44