### PR TITLE
Default QueryVolumes to title sort so editing a volume can't evict it

### DIFF
--- a/data/volume.go
+++ b/data/volume.go
@@ -331,6 +331,13 @@ func QueryVolumes(c context.Context, params apiutil.QueryParams) ([]*vo.VolumeVO
 
 	filter, sort, projection := apiutil.ConvertQueryParams(params)
 	filter = append(filter, bson.E{Key: "state", Value: string(models.VersionStateLive)})
+	if len(sort) == 0 {
+		// Without an explicit sort, Mongo returns natural (insertion) order - stable for an
+		// untouched record, but an edit re-inserts that record's new live version, so it jumps
+		// to the back of natural order and can fall outside a caller's default page size. A
+		// browse list shouldn't reorder itself just because one record was edited.
+		sort = bson.D{{Key: "title", Value: 1}}
+	}
 	logging.Logger.Debug("query volumes", "filter", filter, "sort", sort, "projection", projection)
 
 	versions, err := database.Query[models.VolumeVersion](volumeVersionCollection, filter, sort, projection, params.Start, params.Limit)

--- a/data/volume_test.go
+++ b/data/volume_test.go
@@ -102,6 +102,29 @@ func (suite *VolumeDataTestSuite) TestQueryVolumesProjected() {
 	assert.NotEmpty(suite.T(), volumes)
 }
 
+// TestQueryVolumesDefaultsToTitleSortSoEditingDoesNotEvictARecord reproduces a live-observed
+// bug: with no explicit sort, QueryVolumes used Mongo's natural (insertion) order, so editing a
+// volume - which inserts a new live version document rather than mutating one in place - moved
+// that volume to the back of natural order and could push it past a caller's page limit
+// entirely. A browse list must not reorder itself just because one record was edited.
+func (suite *VolumeDataTestSuite) TestQueryVolumesDefaultsToTitleSortSoEditingDoesNotEvictARecord() {
+	// "AAA Volume" sorts first alphabetically but is added and edited last, so it's the most
+	// recently inserted live version - the position natural order would put at the back.
+	for i := 0; i < 5; i++ {
+		_, err := AddVolume(suite.T().Context(), &vo.VolumeVO{Title: "Filler Volume"})
+		assert.NoError(suite.T(), err)
+	}
+	firstID, err := AddVolume(suite.T().Context(), &vo.VolumeVO{Title: "AAA Volume"})
+	assert.NoError(suite.T(), err)
+	_, err = UpdateVolume(suite.T().Context(), *firstID, &vo.VolumeVO{Title: "AAA Volume", Description: "edited"}, models.VersionStateLive)
+	assert.NoError(suite.T(), err)
+
+	volumes, err := QueryVolumes(suite.T().Context(), apiutil.QueryParams{Start: 0, Limit: 3})
+	assert.NoError(suite.T(), err)
+	assert.Len(suite.T(), volumes, 3)
+	assert.Equal(suite.T(), "AAA Volume", volumes[0].Title)
+}
+
 func (suite *VolumeDataTestSuite) TestQueryVolumesPaged() {
 	params := apiutil.QueryParams{
 		Limit: 10,


### PR DESCRIPTION
Without an explicit sort, QueryVolumes used Mongo's natural (insertion) order. Editing a
volume inserts a new live version document rather than mutating one in place, so an edited
volume jumps to the back of natural order.

Observed live on dev.sweetrpg.com: an edited volume ("A Glorious Death") vanished entirely
from the default-limit browse listing, because the edit that touched it pushed it past the
page size (50) - unrelated to any pagination bug, purely an ordering one.

Defaults to title-ascending when the caller doesn't specify a sort. Added a regression test
that reproduces the exact failure mode (edit a record, confirm it still appears in a
size-limited unsorted-by-caller query) - fails on the old code, passes with the fix.

Verified GetPublisher/StudioVersion/etc. equivalents (QueryPublishers/QueryStudios/
QueryLicenses/QueryPersons) are not affected - they list from the stable meta collection,
which isn't re-inserted on edit, unlike QueryVolumes which lists from the version collection
directly.

Part of sweetrpg/platform#44