### PR TITLE
feat(stats): add per-entity-type count/most-recent stats

### DIFF
--- a/data/entity_versioning.go
+++ b/data/entity_versioning.go
@@ -51,9 +51,59 @@ type entityVersioningConfig[T any] struct {
 	setID             func(*T, string)
 	setRecordID       func(*T, string)
 	setVersion        func(*T, int)
+	// recordID/displayName back the landing-page summary's per-type stats() query (catalog-
+	// landing-page-summary) - the only two fields that query needs beyond what lifecycle()
+	// already exposes (State, SubmittedAt).
+	recordID    func(*T) string
+	displayName func(*T) string
 	// fields are the substantive fields a submission can change and a review can selectively
 	// accept - everything on T except its version-lifecycle bookkeeping.
 	fields map[string]entityFieldAccessor[T]
+}
+
+// TypeStats is one entity type's catalog-landing-page-summary card: a live-record count plus
+// the single most recently submitted live record, or zero-value/nil fields if the type has no
+// live records yet (see spec's "degrades gracefully for an empty entity type" requirement).
+type TypeStats struct {
+	Count          int
+	LastUpdated    *time.Time
+	MostRecentID   string
+	MostRecentName string
+}
+
+// stats computes a TypeStats over cfg's live version collection - sorted-descending-limit-1 for
+// the most recent record (design.md's decision: necessary anyway since "most recent" needs the
+// specific record, not just a max timestamp, unlike GetCatalogStats' volume-only precedent) plus
+// a separate unlimited count query, matching this package's existing "no driver-level
+// CountDocuments" convention (see GetCatalogStats).
+func (cfg entityVersioningConfig[T]) stats(c context.Context) (*TypeStats, error) {
+	filter := bson.D{{Key: "state", Value: string(models.VersionStateLive)}}
+
+	countProjection := bson.D{{Key: "record_id", Value: 1}}
+	all, err := database.Query[T](cfg.versionCollection, filter, nil, countProjection, 0, 0)
+	if err != nil {
+		return nil, fmt.Errorf("%s: count live versions: %w", cfg.typeName, err)
+	}
+
+	stats := &TypeStats{Count: len(all)}
+	if stats.Count == 0 {
+		return stats, nil
+	}
+
+	sortOrder := bson.D{{Key: "submitted_at", Value: -1}}
+	recent, err := database.Query[T](cfg.versionCollection, filter, sortOrder, nil, 0, 1)
+	if err != nil {
+		return nil, fmt.Errorf("%s: query most recent version: %w", cfg.typeName, err)
+	}
+	if len(recent) == 0 {
+		return stats, nil
+	}
+
+	submittedAt := cfg.lifecycle(recent[0]).SubmittedAt
+	stats.LastUpdated = &submittedAt
+	stats.MostRecentID = cfg.recordID(recent[0])
+	stats.MostRecentName = cfg.displayName(recent[0])
+	return stats, nil
 }
 
 func (cfg entityVersioningConfig[T]) ensureIndexes(c context.Context) error {

--- a/data/license_versioning.go
+++ b/data/license_versioning.go
@@ -27,6 +27,8 @@ var licenseVersioning = entityVersioningConfig[models.LicenseVersion]{
 	setID:             func(v *models.LicenseVersion, id string) { v.ID = id },
 	setRecordID:       func(v *models.LicenseVersion, id string) { v.RecordID = id },
 	setVersion:        func(v *models.LicenseVersion, n int) { v.Version = n },
+	recordID:          func(v *models.LicenseVersion) string { return v.RecordID },
+	displayName:       func(v *models.LicenseVersion) string { return v.Title },
 	fields: map[string]entityFieldAccessor[models.LicenseVersion]{
 		"title":         {get: func(v *models.LicenseVersion) any { return v.Title }, set: func(v *models.LicenseVersion, val any) { v.Title = val.(string) }},
 		"short_title":   {get: func(v *models.LicenseVersion) any { return v.ShortTitle }, set: func(v *models.LicenseVersion, val any) { v.ShortTitle = val.(string) }},
@@ -233,4 +235,9 @@ func MigrateLicenses(c context.Context) (int, error) {
 			}
 		},
 	})
+}
+
+// GetLicenseStats returns the licenses landing-page-summary card's count/most-recent data.
+func GetLicenseStats(c context.Context) (*TypeStats, error) {
+	return licenseVersioning.stats(c)
 }

--- a/data/person_versioning.go
+++ b/data/person_versioning.go
@@ -26,6 +26,8 @@ var personVersioning = entityVersioningConfig[models.PersonVersion]{
 	setID:             func(v *models.PersonVersion, id string) { v.ID = id },
 	setRecordID:       func(v *models.PersonVersion, id string) { v.RecordID = id },
 	setVersion:        func(v *models.PersonVersion, n int) { v.Version = n },
+	recordID:          func(v *models.PersonVersion) string { return v.RecordID },
+	displayName:       func(v *models.PersonVersion) string { return v.Name },
 	fields: map[string]entityFieldAccessor[models.PersonVersion]{
 		"name":       {get: func(v *models.PersonVersion) any { return v.Name }, set: func(v *models.PersonVersion, val any) { v.Name = val.(string) }},
 		"notes":      {get: func(v *models.PersonVersion) any { return v.Notes }, set: func(v *models.PersonVersion, val any) { v.Notes = val.(string) }},
@@ -216,4 +218,9 @@ func MigratePersons(c context.Context) (int, error) {
 			}
 		},
 	})
+}
+
+// GetPersonStats returns the persons landing-page-summary card's count/most-recent data.
+func GetPersonStats(c context.Context) (*TypeStats, error) {
+	return personVersioning.stats(c)
 }

--- a/data/publisher_versioning.go
+++ b/data/publisher_versioning.go
@@ -27,6 +27,8 @@ var publisherVersioning = entityVersioningConfig[models.PublisherVersion]{
 	setID:             func(v *models.PublisherVersion, id string) { v.ID = id },
 	setRecordID:       func(v *models.PublisherVersion, id string) { v.RecordID = id },
 	setVersion:        func(v *models.PublisherVersion, n int) { v.Version = n },
+	recordID:          func(v *models.PublisherVersion) string { return v.RecordID },
+	displayName:       func(v *models.PublisherVersion) string { return v.Name },
 	fields: map[string]entityFieldAccessor[models.PublisherVersion]{
 		"name":       {get: func(v *models.PublisherVersion) any { return v.Name }, set: func(v *models.PublisherVersion, val any) { v.Name = val.(string) }},
 		"address":    {get: func(v *models.PublisherVersion) any { return v.Address }, set: func(v *models.PublisherVersion, val any) { v.Address = val.(string) }},
@@ -226,4 +228,9 @@ func MigratePublishers(c context.Context) (int, error) {
 			}
 		},
 	})
+}
+
+// GetPublisherStats returns the publishers landing-page-summary card's count/most-recent data.
+func GetPublisherStats(c context.Context) (*TypeStats, error) {
+	return publisherVersioning.stats(c)
 }

--- a/data/studio_test.go
+++ b/data/studio_test.go
@@ -69,6 +69,24 @@ func (suite *StudioDataTestSuite) TestAcceptStudioVersionFullAccept() {
 	assert.Equal(suite.T(), "Proposed Studio", fetched.Name)
 }
 
+func (suite *StudioDataTestSuite) TestGetStudioStatsReflectsMostRecent() {
+	stats, err := GetStudioStats(suite.T().Context())
+	assert.NoError(suite.T(), err)
+	assert.GreaterOrEqual(suite.T(), stats.Count, 1)
+	assert.NotNil(suite.T(), stats.LastUpdated)
+	assert.NotEmpty(suite.T(), stats.MostRecentID)
+	assert.NotEmpty(suite.T(), stats.MostRecentName)
+
+	secondID, err := AddStudio(suite.T().Context(), &vo.StudioVO{Name: "Second Studio"})
+	assert.NoError(suite.T(), err)
+
+	updated, err := GetStudioStats(suite.T().Context())
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), stats.Count+1, updated.Count)
+	assert.Equal(suite.T(), *secondID, updated.MostRecentID)
+	assert.Equal(suite.T(), "Second Studio", updated.MostRecentName)
+}
+
 func TestStudioDbTestSuite(t *testing.T) {
 	suite.Run(t, new(StudioDataTestSuite))
 }

--- a/data/studio_versioning.go
+++ b/data/studio_versioning.go
@@ -27,6 +27,8 @@ var studioVersioning = entityVersioningConfig[models.StudioVersion]{
 	setID:             func(v *models.StudioVersion, id string) { v.ID = id },
 	setRecordID:       func(v *models.StudioVersion, id string) { v.RecordID = id },
 	setVersion:        func(v *models.StudioVersion, n int) { v.Version = n },
+	recordID:          func(v *models.StudioVersion) string { return v.RecordID },
+	displayName:       func(v *models.StudioVersion) string { return v.Name },
 	fields: map[string]entityFieldAccessor[models.StudioVersion]{
 		"name":       {get: func(v *models.StudioVersion) any { return v.Name }, set: func(v *models.StudioVersion, val any) { v.Name = val.(string) }},
 		"website":    {get: func(v *models.StudioVersion) any { return v.Website }, set: func(v *models.StudioVersion, val any) { v.Website = val.(url.URL) }},
@@ -219,4 +221,9 @@ func MigrateStudios(c context.Context) (int, error) {
 			}
 		},
 	})
+}
+
+// GetStudioStats returns the studios landing-page-summary card's count/most-recent data.
+func GetStudioStats(c context.Context) (*TypeStats, error) {
+	return studioVersioning.stats(c)
 }

--- a/data/system_versioning.go
+++ b/data/system_versioning.go
@@ -30,6 +30,8 @@ var systemVersioning = entityVersioningConfig[models.SystemVersion]{
 	setID:             func(v *models.SystemVersion, id string) { v.ID = id },
 	setRecordID:       func(v *models.SystemVersion, id string) { v.RecordID = id },
 	setVersion:        func(v *models.SystemVersion, n int) { v.Version = n },
+	recordID:          func(v *models.SystemVersion) string { return v.RecordID },
+	displayName:       func(v *models.SystemVersion) string { return v.GameSystem },
 	fields: map[string]entityFieldAccessor[models.SystemVersion]{
 		"game_system": {get: func(v *models.SystemVersion) any { return v.GameSystem }, set: func(v *models.SystemVersion, val any) { v.GameSystem = val.(string) }},
 		"edition":     {get: func(v *models.SystemVersion) any { return v.Edition }, set: func(v *models.SystemVersion, val any) { v.Edition = val.(string) }},
@@ -205,4 +207,9 @@ func MigrateSystems(c context.Context) (int, error) {
 			return models.SystemVersion{GameSystem: s.GameSystem, Edition: s.Edition, Notes: s.Notes, Tags: s.Tags}
 		},
 	})
+}
+
+// GetSystemStats returns the systems landing-page-summary card's count/most-recent data.
+func GetSystemStats(c context.Context) (*TypeStats, error) {
+	return systemVersioning.stats(c)
 }

--- a/data/volume.go
+++ b/data/volume.go
@@ -403,3 +403,40 @@ func GetCatalogStats(c context.Context) (*CatalogStats, error) {
 	logging.Logger.Debug("returning catalog stats", "stats", stats)
 	return stats, nil
 }
+
+// GetVolumeTypeStats returns the volumes landing-page-summary card's count/most-recent data -
+// TypeStats-shaped like the other five entity types' Get*Stats (catalog-landing-page-summary),
+// but implemented directly against volumeVersionCollection rather than entityVersioningConfig
+// since Volume isn't on that shared engine (see entity_versioning.go's own doc comment).
+func GetVolumeTypeStats(c context.Context) (*TypeStats, error) {
+	span := tracing.BuildSpanWithParams(c, "volumes", "db-get-volume-type-stats", apiutil.QueryParams{})
+	defer span.End()
+
+	filter := bson.D{{Key: "state", Value: string(models.VersionStateLive)}}
+
+	countProjection := bson.D{{Key: "record_id", Value: 1}}
+	all, err := database.Query[models.VolumeVersion](volumeVersionCollection, filter, nil, countProjection, 0, 0)
+	if err != nil {
+		return nil, fmt.Errorf("volume: count live versions: %w", err)
+	}
+
+	stats := &TypeStats{Count: len(all)}
+	if stats.Count == 0 {
+		return stats, nil
+	}
+
+	sortOrder := bson.D{{Key: "submitted_at", Value: -1}}
+	recent, err := database.Query[models.VolumeVersion](volumeVersionCollection, filter, sortOrder, nil, 0, 1)
+	if err != nil {
+		return nil, fmt.Errorf("volume: query most recent version: %w", err)
+	}
+	if len(recent) == 0 {
+		return stats, nil
+	}
+
+	submittedAt := recent[0].SubmittedAt
+	stats.LastUpdated = &submittedAt
+	stats.MostRecentID = recent[0].RecordID
+	stats.MostRecentName = recent[0].Title
+	return stats, nil
+}


### PR DESCRIPTION
## Summary
Adds `GetPublisherStats`/`GetStudioStats`/`GetPersonStats`/`GetLicenseStats`/`GetSystemStats` (via `entityVersioningConfig`'s new generic `stats()` method) and `GetVolumeTypeStats` (Volume's own, since it isn't on that shared engine) - each returns a `TypeStats{Count, LastUpdated, MostRecentID, MostRecentName}` for one entity type. Backs the `catalog-landing-page-summary` change: catalog-api's `/stats` endpoint gains a per-type shape, catalog-web's landing page replaces its volumes-only grid with a summary card per entity type.

Part of `openspec/changes/catalog-landing-page-summary` (sweetrpg/platform#52).

## Test plan
- [x] `go build ./...` / `go vet ./...`
- [x] MongoDB-backed test suite: `go test ./...` (added `TestGetStudioStatsReflectsMostRecent`, covers the shared `stats()` engine)