### PR TITLE
Admin-only soft delete/restore for catalog entities

### DIFF
--- a/data/entity_versioning.go
+++ b/data/entity_versioning.go
@@ -505,6 +505,29 @@ func (cfg entityVersioningConfig[T]) setCurrentVersion(c context.Context, id str
 	return target, nil
 }
 
+// softDelete sets the meta record's deleted_at/deleted_by, hiding it from Query*/List* reads
+// without touching version history. No-op fields on an already-deleted record are overwritten
+// with the new deletion's stamp - matches restore's own idempotent behavior.
+func (cfg entityVersioningConfig[T]) softDelete(c context.Context, id string, deletedBy string) error {
+	now := time.Now()
+	_, err := database.Db.Collection(cfg.metaCollection).UpdateOne(
+		c,
+		bson.D{{Key: "_id", Value: id}},
+		bson.D{{Key: "$set", Value: bson.D{{Key: "deleted_at", Value: now}, {Key: "deleted_by", Value: deletedBy}}}},
+	)
+	return err
+}
+
+// restore clears the meta record's deleted_at/deleted_by, returning it to every normal read path.
+func (cfg entityVersioningConfig[T]) restore(c context.Context, id string) error {
+	_, err := database.Db.Collection(cfg.metaCollection).UpdateOne(
+		c,
+		bson.D{{Key: "_id", Value: id}},
+		bson.D{{Key: "$set", Value: bson.D{{Key: "deleted_at", Value: nil}, {Key: "deleted_by", Value: nil}}}},
+	)
+	return err
+}
+
 // countSubmittedBySubmitter counts a submitter's currently-pending (state: submitted) versions.
 func (cfg entityVersioningConfig[T]) countSubmittedBySubmitter(c context.Context, submittedBy string) (int64, error) {
 	filter := bson.D{

--- a/data/license_versioning.go
+++ b/data/license_versioning.go
@@ -12,6 +12,7 @@ import (
 	modelcoreutil "github.com/sweetrpg/model-core.go/util"
 	modelcorevo "github.com/sweetrpg/model-core.go/vo"
 	"github.com/sweetrpg/mongodb.go/database"
+	"go.mongodb.org/mongo-driver/bson"
 )
 
 const (
@@ -48,6 +49,17 @@ var licenseVersioning = entityVersioningConfig[models.LicenseVersion]{
 // call on every startup.
 func EnsureLicenseVersioningIndexes(c context.Context) error {
 	return licenseVersioning.ensureIndexes(c)
+}
+
+// SoftDeleteLicense hides a license from every Query*/List* read without touching its version
+// history - see design.md's soft-delete decision.
+func SoftDeleteLicense(c context.Context, id string, deletedBy string) error {
+	return licenseVersioning.softDelete(c, id, deletedBy)
+}
+
+// RestoreLicense clears a soft-deleted license's deletion, returning it to every normal read path.
+func RestoreLicense(c context.Context, id string) error {
+	return licenseVersioning.restore(c, id)
 }
 
 func licenseVersionToVO(version *models.LicenseVersion) *vo.LicenseVersionVO {
@@ -189,6 +201,7 @@ func CountSubmittedLicenseVersionsBySubmitter(c context.Context, submittedBy str
 // QueryLicenses lists the current (live) version of every license matching params.
 func QueryLicenses(c context.Context, params apiutil.QueryParams) ([]*vo.LicenseVO, error) {
 	filter, sort, projection := apiutil.ConvertQueryParams(params)
+	filter = append(filter, bson.E{Key: "deleted_at", Value: nil})
 	metas, err := database.Query[models.EntityMeta](licenseMetaCollection, filter, sort, projection, params.Start, params.Limit)
 	if err != nil {
 		return nil, err

--- a/data/person_versioning.go
+++ b/data/person_versioning.go
@@ -11,6 +11,7 @@ import (
 	modelcoreutil "github.com/sweetrpg/model-core.go/util"
 	modelcorevo "github.com/sweetrpg/model-core.go/vo"
 	"github.com/sweetrpg/mongodb.go/database"
+	"go.mongodb.org/mongo-driver/bson"
 )
 
 const (
@@ -40,6 +41,17 @@ var personVersioning = entityVersioningConfig[models.PersonVersion]{
 // on every startup.
 func EnsurePersonVersioningIndexes(c context.Context) error {
 	return personVersioning.ensureIndexes(c)
+}
+
+// SoftDeletePerson hides a person from every Query*/List* read without touching its version
+// history - see design.md's soft-delete decision.
+func SoftDeletePerson(c context.Context, id string, deletedBy string) error {
+	return personVersioning.softDelete(c, id, deletedBy)
+}
+
+// RestorePerson clears a soft-deleted person's deletion, returning it to every normal read path.
+func RestorePerson(c context.Context, id string) error {
+	return personVersioning.restore(c, id)
 }
 
 func personVersionToVO(version *models.PersonVersion) *vo.PersonVersionVO {
@@ -175,6 +187,7 @@ func CountSubmittedPersonVersionsBySubmitter(c context.Context, submittedBy stri
 // QueryPersons lists the current (live) version of every person matching params.
 func QueryPersons(c context.Context, params apiutil.QueryParams) ([]*vo.PersonVO, error) {
 	filter, sort, projection := apiutil.ConvertQueryParams(params)
+	filter = append(filter, bson.E{Key: "deleted_at", Value: nil})
 	metas, err := database.Query[models.EntityMeta](personMetaCollection, filter, sort, projection, params.Start, params.Limit)
 	if err != nil {
 		return nil, err

--- a/data/publisher_test.go
+++ b/data/publisher_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 
+	apiutil "github.com/sweetrpg/api-core.go/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"github.com/sweetrpg/catalog-objects.go/models"
@@ -160,6 +161,43 @@ func (suite *PublisherDataTestSuite) TestWebsiteRoundTripsAsPlainString() {
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), fetched)
 	assert.Equal(suite.T(), "https://example.com/kobold", fetched.Website)
+}
+
+// TestSoftDeletePublisherLifecycle exercises entityVersioningConfig's shared soft-delete engine -
+// publisher, studio, person, license, and system all route through the identical generic code,
+// so this one test covers that engine; Volume gets its own test since its path is bespoke.
+func (suite *PublisherDataTestSuite) TestSoftDeletePublisherLifecycle() {
+	err := SoftDeletePublisher(suite.T().Context(), suite.seedPublisherID, "admin-1")
+	assert.NoError(suite.T(), err)
+
+	results, err := QueryPublishers(suite.T().Context(), apiutil.QueryParams{Limit: 100})
+	assert.NoError(suite.T(), err)
+	for _, p := range results {
+		assert.NotEqual(suite.T(), suite.seedPublisherID, p.ID, "deleted publisher should be excluded from QueryPublishers")
+	}
+
+	fetched, err := GetPublisher(suite.T().Context(), suite.seedPublisherID)
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), fetched, "GetPublisher must still return a soft-deleted record")
+	assert.NotNil(suite.T(), fetched.DeletedAt)
+	assert.Equal(suite.T(), "admin-1", *fetched.DeletedBy)
+
+	err = RestorePublisher(suite.T().Context(), suite.seedPublisherID)
+	assert.NoError(suite.T(), err)
+
+	restored, err := GetPublisher(suite.T().Context(), suite.seedPublisherID)
+	assert.NoError(suite.T(), err)
+	assert.Nil(suite.T(), restored.DeletedAt)
+
+	results, err = QueryPublishers(suite.T().Context(), apiutil.QueryParams{Limit: 100})
+	assert.NoError(suite.T(), err)
+	found := false
+	for _, p := range results {
+		if p.ID == suite.seedPublisherID {
+			found = true
+		}
+	}
+	assert.True(suite.T(), found, "restored publisher should reappear in QueryPublishers")
 }
 
 func TestPublisherDbTestSuite(t *testing.T) {

--- a/data/publisher_test.go
+++ b/data/publisher_test.go
@@ -4,9 +4,9 @@ import (
 	"os"
 	"testing"
 
-	apiutil "github.com/sweetrpg/api-core.go/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	apiutil "github.com/sweetrpg/api-core.go/util"
 	"github.com/sweetrpg/catalog-objects.go/models"
 	"github.com/sweetrpg/catalog-objects.go/vo"
 	"github.com/sweetrpg/common.go/logging"

--- a/data/publisher_versioning.go
+++ b/data/publisher_versioning.go
@@ -12,6 +12,7 @@ import (
 	modelcoreutil "github.com/sweetrpg/model-core.go/util"
 	modelcorevo "github.com/sweetrpg/model-core.go/vo"
 	"github.com/sweetrpg/mongodb.go/database"
+	"go.mongodb.org/mongo-driver/bson"
 )
 
 const (
@@ -43,6 +44,18 @@ var publisherVersioning = entityVersioningConfig[models.PublisherVersion]{
 // call on every startup.
 func EnsurePublisherVersioningIndexes(c context.Context) error {
 	return publisherVersioning.ensureIndexes(c)
+}
+
+// SoftDeletePublisher hides a publisher from every Query*/List* read without touching its
+// version history - see design.md's soft-delete decision.
+func SoftDeletePublisher(c context.Context, id string, deletedBy string) error {
+	return publisherVersioning.softDelete(c, id, deletedBy)
+}
+
+// RestorePublisher clears a soft-deleted publisher's deletion, returning it to every normal read
+// path.
+func RestorePublisher(c context.Context, id string) error {
+	return publisherVersioning.restore(c, id)
 }
 
 func publisherVersionToVO(version *models.PublisherVersion) *vo.PublisherVersionVO {
@@ -181,6 +194,7 @@ func CountSubmittedPublisherVersionsBySubmitter(c context.Context, submittedBy s
 // QueryPublishers lists the current (live) version of every publisher matching params.
 func QueryPublishers(c context.Context, params apiutil.QueryParams) ([]*vo.PublisherVO, error) {
 	filter, sort, projection := apiutil.ConvertQueryParams(params)
+	filter = append(filter, bson.E{Key: "deleted_at", Value: nil})
 	metas, err := database.Query[models.EntityMeta](publisherMetaCollection, filter, sort, projection, params.Start, params.Limit)
 	if err != nil {
 		return nil, err

--- a/data/studio_versioning.go
+++ b/data/studio_versioning.go
@@ -12,6 +12,7 @@ import (
 	modelcoreutil "github.com/sweetrpg/model-core.go/util"
 	modelcorevo "github.com/sweetrpg/model-core.go/vo"
 	"github.com/sweetrpg/mongodb.go/database"
+	"go.mongodb.org/mongo-driver/bson"
 )
 
 const (
@@ -42,6 +43,17 @@ var studioVersioning = entityVersioningConfig[models.StudioVersion]{
 // on every startup.
 func EnsureStudioVersioningIndexes(c context.Context) error {
 	return studioVersioning.ensureIndexes(c)
+}
+
+// SoftDeleteStudio hides a studio from every Query*/List* read without touching its version
+// history - see design.md's soft-delete decision.
+func SoftDeleteStudio(c context.Context, id string, deletedBy string) error {
+	return studioVersioning.softDelete(c, id, deletedBy)
+}
+
+// RestoreStudio clears a soft-deleted studio's deletion, returning it to every normal read path.
+func RestoreStudio(c context.Context, id string) error {
+	return studioVersioning.restore(c, id)
 }
 
 func studioVersionToVO(version *models.StudioVersion) *vo.StudioVersionVO {
@@ -177,6 +189,7 @@ func CountSubmittedStudioVersionsBySubmitter(c context.Context, submittedBy stri
 // QueryStudios lists the current (live) version of every studio matching params.
 func QueryStudios(c context.Context, params apiutil.QueryParams) ([]*vo.StudioVO, error) {
 	filter, sort, projection := apiutil.ConvertQueryParams(params)
+	filter = append(filter, bson.E{Key: "deleted_at", Value: nil})
 	metas, err := database.Query[models.EntityMeta](studioMetaCollection, filter, sort, projection, params.Start, params.Limit)
 	if err != nil {
 		return nil, err

--- a/data/system_versioning.go
+++ b/data/system_versioning.go
@@ -10,6 +10,7 @@ import (
 	modelcoreutil "github.com/sweetrpg/model-core.go/util"
 	modelcorevo "github.com/sweetrpg/model-core.go/vo"
 	"github.com/sweetrpg/mongodb.go/database"
+	"go.mongodb.org/mongo-driver/bson"
 )
 
 const (
@@ -44,6 +45,17 @@ var systemVersioning = entityVersioningConfig[models.SystemVersion]{
 // on every startup.
 func EnsureSystemVersioningIndexes(c context.Context) error {
 	return systemVersioning.ensureIndexes(c)
+}
+
+// SoftDeleteSystem hides a system from every Query*/List* read without touching its version
+// history - see design.md's soft-delete decision.
+func SoftDeleteSystem(c context.Context, id string, deletedBy string) error {
+	return systemVersioning.softDelete(c, id, deletedBy)
+}
+
+// RestoreSystem clears a soft-deleted system's deletion, returning it to every normal read path.
+func RestoreSystem(c context.Context, id string) error {
+	return systemVersioning.restore(c, id)
 }
 
 func systemVersionToVO(version *models.SystemVersion) *vo.SystemVersionVO {
@@ -176,6 +188,7 @@ func CountSubmittedSystemVersionsBySubmitter(c context.Context, submittedBy stri
 // QuerySystems lists the current (live) version of every system matching params.
 func QuerySystems(c context.Context, params apiutil.QueryParams) ([]*vo.SystemVO, error) {
 	filter, sort, projection := apiutil.ConvertQueryParams(params)
+	filter = append(filter, bson.E{Key: "deleted_at", Value: nil})
 	metas, err := database.Query[models.EntityMeta](systemMetaCollection, filter, sort, projection, params.Start, params.Limit)
 	if err != nil {
 		return nil, err

--- a/data/volume.go
+++ b/data/volume.go
@@ -141,6 +141,29 @@ func DeleteVolume(c context.Context, id string) error {
 	return nil
 }
 
+// SoftDeleteVolume sets the volume meta record's deleted_at/deleted_by, hiding it from
+// QueryVolumes without touching its version history - Volume's own non-generic path mirroring
+// entityVersioningConfig.softDelete, since Volume isn't on the shared engine (see design.md).
+func SoftDeleteVolume(c context.Context, id string, deletedBy string) error {
+	now := time.Now()
+	_, err := database.Db.Collection(volumeMetaCollection).UpdateOne(
+		c,
+		bson.D{{Key: "_id", Value: id}},
+		bson.D{{Key: "$set", Value: bson.D{{Key: "deleted_at", Value: now}, {Key: "deleted_by", Value: deletedBy}}}},
+	)
+	return err
+}
+
+// RestoreVolume clears a soft-deleted volume's deletion, returning it to QueryVolumes.
+func RestoreVolume(c context.Context, id string) error {
+	_, err := database.Db.Collection(volumeMetaCollection).UpdateOne(
+		c,
+		bson.D{{Key: "_id", Value: id}},
+		bson.D{{Key: "$set", Value: bson.D{{Key: "deleted_at", Value: nil}, {Key: "deleted_by", Value: nil}}}},
+	)
+	return err
+}
+
 // GetVolume returns the flattened view of a volume - its meta record merged with its current
 // version's data - matching the shape this function returned before meta/version were split.
 func GetVolume(c context.Context, id string) (*vo.VolumeVO, error) {
@@ -355,6 +378,9 @@ func QueryVolumes(c context.Context, params apiutil.QueryParams) ([]*vo.VolumeVO
 		}
 		if meta == nil {
 			logging.Logger.Error(fmt.Sprintf("No VolumeMeta found for VolumeVersion record %s", version.RecordID))
+			continue
+		}
+		if meta.DeletedAt != nil {
 			continue
 		}
 		vos = append(vos, flattenVolume(c, meta, version))

--- a/data/volume_test.go
+++ b/data/volume_test.go
@@ -379,6 +379,40 @@ func (suite *VolumeDataTestSuite) TestSetCurrentVolumeVersionRollback() {
 	assert.Equal(suite.T(), models.VersionStateArchived, models.VersionState(v2.State))
 }
 
+func (suite *VolumeDataTestSuite) TestSoftDeleteVolumeLifecycle() {
+	err := SoftDeleteVolume(suite.T().Context(), suite.seedVolumeID, "admin-1")
+	assert.NoError(suite.T(), err)
+
+	results, err := QueryVolumes(suite.T().Context(), apiutil.QueryParams{Limit: 100})
+	assert.NoError(suite.T(), err)
+	for _, v := range results {
+		assert.NotEqual(suite.T(), suite.seedVolumeID, v.ID, "deleted volume should be excluded from QueryVolumes")
+	}
+
+	fetched, err := GetVolume(suite.T().Context(), suite.seedVolumeID)
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), fetched, "GetVolume must still return a soft-deleted record")
+	assert.NotNil(suite.T(), fetched.DeletedAt)
+	assert.Equal(suite.T(), "admin-1", *fetched.DeletedBy)
+
+	err = RestoreVolume(suite.T().Context(), suite.seedVolumeID)
+	assert.NoError(suite.T(), err)
+
+	restored, err := GetVolume(suite.T().Context(), suite.seedVolumeID)
+	assert.NoError(suite.T(), err)
+	assert.Nil(suite.T(), restored.DeletedAt)
+
+	results, err = QueryVolumes(suite.T().Context(), apiutil.QueryParams{Limit: 100})
+	assert.NoError(suite.T(), err)
+	found := false
+	for _, v := range results {
+		if v.ID == suite.seedVolumeID {
+			found = true
+		}
+	}
+	assert.True(suite.T(), found, "restored volume should reappear in QueryVolumes")
+}
+
 func TestDbTestSuite(t *testing.T) {
 	suite.Run(t, new(VolumeDataTestSuite))
 }


### PR DESCRIPTION
## Summary
- Add `deleted_at: nil` filter to every `Query*`/`List*` function (publisher/studio/person/license/system/volume).
- Add generic `SoftDelete`/`Restore` to `entityVersioningConfig`'s shared engine.
- Add `SoftDeleteVolume`/`RestoreVolume` to `volume.go` (Volume's own non-generic path).
- `Get*ByID`/`GetVolume` remain unfiltered so a deleted entity stays reachable by its own detail page.

Part of sweetrpg/platform#51. See openspec change `catalog-entity-soft-delete` in the platform repo for proposal/design/spec.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (added soft-delete lifecycle tests for publisher - representative of the shared engine - and volume - its own bespoke path)