### PR TITLE
feat(system): add QuerySystems, backing catalog-api's missing /systems list route

### DIFF
--- a/data/system_client.go
+++ b/data/system_client.go
@@ -37,6 +37,31 @@ func GetSystem(c context.Context, id string) (*vo.SystemVO, error) {
 	}, nil
 }
 
+// QuerySystems lists every live game system against gamesystems-api's current versions. Backs
+// catalog-api's /systems list route - a nil GameSystemsClient (unconfigured GAMESYSTEMS_API_URL)
+// degrades to an empty list rather than an error, matching GetSystem's fail-open convention.
+func QuerySystems(c context.Context) ([]*vo.SystemVO, error) {
+	if GameSystemsClient == nil {
+		return []*vo.SystemVO{}, nil
+	}
+	systems, err := GameSystemsClient.List(c)
+	if err != nil {
+		return nil, err
+	}
+	vos := make([]*vo.SystemVO, len(systems))
+	for i, system := range systems {
+		vos[i] = &vo.SystemVO{
+			ID: system.ID, GameSystem: system.Name, Edition: system.Edition, Notes: system.Notes,
+			Tags: system.Tags,
+			AuditableVO: modelcorevo.AuditableVO{
+				CreatedAt: system.CreatedAt, CreatedBy: system.CreatedBy,
+				UpdatedAt: system.CreatedAt, UpdatedBy: system.CreatedBy,
+			},
+		}
+	}
+	return vos, nil
+}
+
 // GetSystemStats returns the systems landing-page-summary card, computed by gamesystems-api.
 func GetSystemStats(c context.Context) (*TypeStats, error) {
 	if GameSystemsClient == nil {

--- a/gamesystems/client.go
+++ b/gamesystems/client.go
@@ -96,19 +96,10 @@ func (c *Client) Get(ctx context.Context, id string) (*System, error) {
 	}, nil
 }
 
-// Stats is the catalog-landing-page-summary card gamesystems-api backs: a live-record count
-// plus the single most recently submitted live record.
-type Stats struct {
-	Count          int
-	LastUpdated    *time.Time
-	MostRecentID   string
-	MostRecentName string
-}
-
-// GetStats computes Stats from GET /systems (every live game system's current version) - no
-// dedicated stats endpoint on gamesystems-api yet, and system counts are small enough that
-// computing this client-side is simpler than adding one. Revisit if that stops being true.
-func (c *Client) GetStats(ctx context.Context) (*Stats, error) {
+// List resolves every live game system against gamesystems-api's current versions - backs
+// catalog-api's /systems list route (the autocomplete/picker source for a volume's system
+// associations) as well as GetStats below.
+func (c *Client) List(ctx context.Context) ([]*System, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/systems", nil)
 	if err != nil {
 		return nil, fmt.Errorf("gamesystems: build list request: %w", err)
@@ -129,13 +120,41 @@ func (c *Client) GetStats(ctx context.Context) (*Stats, error) {
 		return nil, fmt.Errorf("gamesystems: decode list response: %w", err)
 	}
 
-	stats := &Stats{Count: len(all)}
-	for _, gs := range all {
-		if stats.LastUpdated == nil || gs.SubmittedAt.After(*stats.LastUpdated) {
-			submittedAt := gs.SubmittedAt
-			stats.LastUpdated = &submittedAt
-			stats.MostRecentID = gs.RecordID
-			stats.MostRecentName = gs.Name
+	systems := make([]*System, len(all))
+	for i, gs := range all {
+		systems[i] = &System{
+			ID: gs.RecordID, Name: gs.Name, Edition: gs.Edition, Notes: gs.Notes,
+			Tags: toTagVOs(gs.Tags), CreatedBy: gs.SubmittedBy, CreatedAt: gs.SubmittedAt,
+		}
+	}
+	return systems, nil
+}
+
+// Stats is the catalog-landing-page-summary card gamesystems-api backs: a live-record count
+// plus the single most recently submitted live record.
+type Stats struct {
+	Count          int
+	LastUpdated    *time.Time
+	MostRecentID   string
+	MostRecentName string
+}
+
+// GetStats computes Stats from List - no dedicated stats endpoint on gamesystems-api yet, and
+// system counts are small enough that computing this client-side is simpler than adding one.
+// Revisit if that stops being true.
+func (c *Client) GetStats(ctx context.Context) (*Stats, error) {
+	systems, err := c.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	stats := &Stats{Count: len(systems)}
+	for _, s := range systems {
+		if stats.LastUpdated == nil || s.CreatedAt.After(*stats.LastUpdated) {
+			createdAt := s.CreatedAt
+			stats.LastUpdated = &createdAt
+			stats.MostRecentID = s.ID
+			stats.MostRecentName = s.Name
 		}
 	}
 	return stats, nil


### PR DESCRIPTION
## Summary
- \`GameSystemsClient.Get(id)\` already resolved a single system, but nothing listed every game system - the data catalog-api's \`/systems\` picker/autocomplete route needs, and which doesn't exist yet (companion catalog-api PR follows).
- Added \`gamesystems.Client.List(ctx) ([]*System, error)\` and \`data.QuerySystems(ctx) ([]*vo.SystemVO, error)\`, mirroring \`GetSystem\`'s shape and fail-open-on-nil-client convention.
- Refactored \`GetStats\` to call \`List\` internally instead of duplicating the HTTP-list/decode logic.

## Test plan
- [x] \`go build\`/\`go vet\`/\`go test\` pass locally (real MongoDB via docker)