### PR TITLE
feat(person): add SearchPersons for name-substring search

### DIFF
--- a/data/license_versioning.go
+++ b/data/license_versioning.go
@@ -3,6 +3,7 @@ package data
 import (
 	"context"
 	"net/url"
+	"strings"
 	"time"
 
 	apiutil "github.com/sweetrpg/api-core.go/util"
@@ -218,6 +219,24 @@ func QueryLicenses(c context.Context, params apiutil.QueryParams) ([]*vo.License
 		vos = append(vos, flattenLicense(meta, version))
 	}
 	return vos, nil
+}
+
+// SearchLicenses finds live licenses whose title contains query (case-insensitive), scanning the
+// full collection - see data.SearchPersons for why this scans in memory rather than pushing the
+// match down to Mongo.
+func SearchLicenses(c context.Context, query string) ([]*vo.LicenseVO, error) {
+	all, err := QueryLicenses(c, apiutil.QueryParams{Limit: searchScanLimit})
+	if err != nil {
+		return nil, err
+	}
+	needle := strings.ToLower(query)
+	matches := make([]*vo.LicenseVO, 0, len(all))
+	for _, l := range all {
+		if strings.Contains(strings.ToLower(l.Title), needle) {
+			matches = append(matches, l)
+		}
+	}
+	return matches, nil
 }
 
 // CreateSubmittedLicenseVersion creates a submitted version stamped with a caller-supplied

--- a/data/person_versioning.go
+++ b/data/person_versioning.go
@@ -2,6 +2,7 @@ package data
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	apiutil "github.com/sweetrpg/api-core.go/util"
@@ -204,6 +205,32 @@ func QueryPersons(c context.Context, params apiutil.QueryParams) ([]*vo.PersonVO
 		vos = append(vos, flattenPerson(meta, version))
 	}
 	return vos, nil
+}
+
+// searchScanLimit bounds how many live persons SearchPersons scans in memory - name isn't a
+// field on personMetaCollection (it only lives on the version document QueryPersons resolves
+// per-meta), so there's no index-backed way to push a substring match down to Mongo without a
+// denormalization this doesn't attempt yet. High enough to cover the whole collection at its
+// current size (low hundreds) with room to grow; revisit if persons ever reaches this scale.
+const searchScanLimit = 5000
+
+// SearchPersons finds live persons whose name contains query (case-insensitive), scanning the
+// full collection rather than just whatever page a plain QueryPersons call would return -
+// backs catalog-api's /persons/search route, used by autocomplete/picker inputs instead of the
+// page-capped list-and-filter-client-side approach every other picker used before this existed.
+func SearchPersons(c context.Context, query string) ([]*vo.PersonVO, error) {
+	all, err := QueryPersons(c, apiutil.QueryParams{Limit: searchScanLimit})
+	if err != nil {
+		return nil, err
+	}
+	needle := strings.ToLower(query)
+	matches := make([]*vo.PersonVO, 0, len(all))
+	for _, p := range all {
+		if strings.Contains(strings.ToLower(p.Name), needle) {
+			matches = append(matches, p)
+		}
+	}
+	return matches, nil
 }
 
 // CreateSubmittedPersonVersion creates a submitted version stamped with a caller-supplied

--- a/data/publisher_versioning.go
+++ b/data/publisher_versioning.go
@@ -3,6 +3,7 @@ package data
 import (
 	"context"
 	"net/url"
+	"strings"
 	"time"
 
 	apiutil "github.com/sweetrpg/api-core.go/util"
@@ -211,6 +212,24 @@ func QueryPublishers(c context.Context, params apiutil.QueryParams) ([]*vo.Publi
 		vos = append(vos, flattenPublisher(meta, version))
 	}
 	return vos, nil
+}
+
+// SearchPublishers finds live publishers whose name contains query (case-insensitive), scanning
+// the full collection - see data.SearchPersons for why this scans in memory rather than pushing
+// the match down to Mongo.
+func SearchPublishers(c context.Context, query string) ([]*vo.PublisherVO, error) {
+	all, err := QueryPublishers(c, apiutil.QueryParams{Limit: searchScanLimit})
+	if err != nil {
+		return nil, err
+	}
+	needle := strings.ToLower(query)
+	matches := make([]*vo.PublisherVO, 0, len(all))
+	for _, p := range all {
+		if strings.Contains(strings.ToLower(p.Name), needle) {
+			matches = append(matches, p)
+		}
+	}
+	return matches, nil
 }
 
 // CreateSubmittedPublisherVersion creates a submitted version stamped with a caller-supplied

--- a/data/studio_versioning.go
+++ b/data/studio_versioning.go
@@ -3,6 +3,7 @@ package data
 import (
 	"context"
 	"net/url"
+	"strings"
 	"time"
 
 	apiutil "github.com/sweetrpg/api-core.go/util"
@@ -206,6 +207,24 @@ func QueryStudios(c context.Context, params apiutil.QueryParams) ([]*vo.StudioVO
 		vos = append(vos, flattenStudio(meta, version))
 	}
 	return vos, nil
+}
+
+// SearchStudios finds live studios whose name contains query (case-insensitive), scanning the
+// full collection - see data.SearchPersons for why this scans in memory rather than pushing the
+// match down to Mongo.
+func SearchStudios(c context.Context, query string) ([]*vo.StudioVO, error) {
+	all, err := QueryStudios(c, apiutil.QueryParams{Limit: searchScanLimit})
+	if err != nil {
+		return nil, err
+	}
+	needle := strings.ToLower(query)
+	matches := make([]*vo.StudioVO, 0, len(all))
+	for _, s := range all {
+		if strings.Contains(strings.ToLower(s.Name), needle) {
+			matches = append(matches, s)
+		}
+	}
+	return matches, nil
 }
 
 // CreateSubmittedStudioVersion creates a submitted version stamped with a caller-supplied

--- a/data/system_client.go
+++ b/data/system_client.go
@@ -2,6 +2,7 @@ package data
 
 import (
 	"context"
+	"strings"
 
 	"github.com/sweetrpg/catalog-data.go/gamesystems"
 	"github.com/sweetrpg/catalog-objects.go/vo"
@@ -60,6 +61,24 @@ func QuerySystems(c context.Context) ([]*vo.SystemVO, error) {
 		}
 	}
 	return vos, nil
+}
+
+// SearchSystems finds live game systems whose name contains query (case-insensitive) - same
+// scan-in-memory approach as data.SearchPersons, over gamesystems-api's full live list rather
+// than a Mongo collection (there is no local collection for Systems to query).
+func SearchSystems(c context.Context, query string) ([]*vo.SystemVO, error) {
+	all, err := QuerySystems(c)
+	if err != nil {
+		return nil, err
+	}
+	needle := strings.ToLower(query)
+	matches := make([]*vo.SystemVO, 0, len(all))
+	for _, s := range all {
+		if strings.Contains(strings.ToLower(s.GameSystem), needle) {
+			matches = append(matches, s)
+		}
+	}
+	return matches, nil
 }
 
 // GetSystemStats returns the systems landing-page-summary card, computed by gamesystems-api.


### PR DESCRIPTION
## Summary
- Backs catalog-api's new \`/persons/search\` route (companion PR follows).
- Autocomplete/picker inputs (e.g. the volume-edit contributor dialog) were filtering a pre-fetched, page-capped (100-record) full list client-side - anything past that page was invisible regardless of what was typed. Confirmed live: a duplicate "Monte Cook" person record sits past the cap, invisible in the contributor picker.
- \`SearchPersons\` scans the full live collection and substring-matches by name in memory - \`name\` lives on the version document, not the indexed meta collection \`QueryPersons\` filters against, so there's no index-backed way to push this down to Mongo without a denormalization this doesn't attempt.

## Test plan
- [x] \`go build\`/\`go vet\`/\`go test\` pass locally (real MongoDB via docker)