### PR TITLE
fix(contribution): single role per contribution

### DIFF
--- a/data/contribution.go
+++ b/data/contribution.go
@@ -57,7 +57,7 @@ func contributionModelToVO(c context.Context, model *models.Contribution) *vo.Co
 		ID:     model.ID,
 		Person: personVO,
 		Volume: volumeVO,
-		Roles:  model.Roles,
+		Role:   model.Role,
 		AuditableVO: modelcorevo.AuditableVO{
 			CreatedAt: model.CreatedAt,
 			CreatedBy: model.CreatedBy,
@@ -110,10 +110,10 @@ func QueryContributionsByVolume(c context.Context, volumeID string) ([]*vo.Contr
 	return vos, nil
 }
 
-// AddContribution creates a new person-to-volume credit and returns its ID.
-func AddContribution(c context.Context, personID, volumeID string, roles []string, createdBy string) (*string, error) {
+// AddContribution creates a new person-to-volume credit with a single role and returns its ID.
+func AddContribution(c context.Context, personID, volumeID, role, createdBy string) (*string, error) {
 	_, span := otel.Tracer("contribution").Start(c, "db-add-contribution", oteltrace.WithAttributes(
-		attribute.String("personId", personID), attribute.String("volumeId", volumeID)))
+		attribute.String("personId", personID), attribute.String("volumeId", volumeID), attribute.String("role", role)))
 	defer span.End()
 
 	now := time.Now()
@@ -121,7 +121,7 @@ func AddContribution(c context.Context, personID, volumeID string, roles []strin
 		ID:       primitive.NewObjectID().Hex(),
 		PersonId: personID,
 		VolumeId: volumeID,
-		Roles:    roles,
+		Role:     role,
 		Auditable: modelcore.Auditable{
 			CreatedAt: now,
 			CreatedBy: createdBy,

--- a/data/contribution_test.go
+++ b/data/contribution_test.go
@@ -16,7 +16,7 @@ func (suite *VolumeDataTestSuite) TestAddContributionAndQueryByVolume() {
 	assert.NoError(suite.T(), err)
 	assert.NotEmpty(suite.T(), personID)
 
-	id, err := AddContribution(ctx, *personID, suite.seedVolumeID, []string{"Author"}, "auth0|editor")
+	id, err := AddContribution(ctx, *personID, suite.seedVolumeID, "Author", "auth0|editor")
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), id)
 	assert.NotEmpty(suite.T(), *id)
@@ -26,7 +26,7 @@ func (suite *VolumeDataTestSuite) TestAddContributionAndQueryByVolume() {
 	assert.Len(suite.T(), contributions, 1)
 	assert.NotNil(suite.T(), contributions[0].Person)
 	assert.Equal(suite.T(), *personID, contributions[0].Person.ID)
-	assert.Equal(suite.T(), []string{"Author"}, contributions[0].Roles)
+	assert.Equal(suite.T(), "Author", contributions[0].Role)
 
 	got, err := GetContribution(ctx, *id)
 	assert.NoError(suite.T(), err)
@@ -41,7 +41,7 @@ func (suite *VolumeDataTestSuite) TestDeleteContribution() {
 	assert.NoError(suite.T(), err)
 	assert.NotEmpty(suite.T(), personID)
 
-	id, err := AddContribution(ctx, *personID, suite.seedVolumeID, []string{"Editor"}, "auth0|editor")
+	id, err := AddContribution(ctx, *personID, suite.seedVolumeID, "Editor", "auth0|editor")
 	assert.NoError(suite.T(), err)
 
 	deleted, err := DeleteContribution(ctx, *id)

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.5
 require (
 	github.com/stretchr/testify v1.12.1
 	github.com/sweetrpg/api-core.go v0.1.0
-	github.com/sweetrpg/catalog-objects.go v0.4.1
+	github.com/sweetrpg/catalog-objects.go v0.4.3
 	github.com/sweetrpg/common.go v0.0.16
 	github.com/sweetrpg/model-core.go v0.0.173
 	github.com/sweetrpg/mongodb.go v0.0.193

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,8 @@ github.com/stretchr/testify v1.12.1 h1:EuwCh5fleGS7H32xRwO3wRGT7DxrDhLAT6FF8MpWD
 github.com/stretchr/testify v1.12.1/go.mod h1:MDEgiDPPsNp5cuIrHPPCyornHKgEVbtFUmoNlxoYthg=
 github.com/sweetrpg/api-core.go v0.1.0 h1:mlRoCVmS/QCO11LU8Fnl82xYJhTvI4IXFMgoH34IiA0=
 github.com/sweetrpg/api-core.go v0.1.0/go.mod h1:ka2gLYUlukRaBXiaaohfRSHoNH77oSrTkkik07Z+lj0=
-github.com/sweetrpg/catalog-objects.go v0.4.1 h1:nCWdCXptAeIb99BAiK5w+OpDu4ZXstqaIzvQCka3CVI=
-github.com/sweetrpg/catalog-objects.go v0.4.1/go.mod h1:94LMLsDebNMb629Nv+FHkKq+FI6H8CeCbeDl9RWs2O0=
+github.com/sweetrpg/catalog-objects.go v0.4.3 h1:WukLXUnpMCXyuthx8PVPu3FvqtTCJvjorA5Dwt3vMvw=
+github.com/sweetrpg/catalog-objects.go v0.4.3/go.mod h1:94LMLsDebNMb629Nv+FHkKq+FI6H8CeCbeDl9RWs2O0=
 github.com/sweetrpg/common.go v0.0.16 h1:XT8PwUXz0BOMIITXLjw3G6rEjjRUEs0Xs4+R9o2fVBk=
 github.com/sweetrpg/common.go v0.0.16/go.mod h1:PVpjDIeB/bZYJZk5fc8whuqVJE8K5k/DsO3o+aZFEcE=
 github.com/sweetrpg/model-core.go v0.0.173 h1:mIZ4z0ETkCH7I3Az0jwTFOyh66OTm7Z4/f0Rx/w+5Fk=


### PR DESCRIPTION
AddContribution and the VO mapping now use a single `role` string, matching catalog-objects.go v0.4.3's model change (one document per person/volume/role).