### PR TITLE
Cap SearchVolumes scan at 500, not 5000

### DIFF
--- a/data/volume.go
+++ b/data/volume.go
@@ -411,11 +411,19 @@ func QueryVolumes(c context.Context, params apiutil.QueryParams) ([]*vo.VolumeVO
 	return vos, nil
 }
 
-// SearchVolumes finds live volumes whose title contains query (case-insensitive), scanning the
-// full collection - see data.SearchPersons for why this scans in memory rather than pushing the
-// match down to Mongo.
+// volumeSearchScanLimit is far smaller than the shared searchScanLimit (5000, used by
+// SearchPublishers/SearchPersons/etc.) - QueryVolumes resolves each volume's full relation set
+// (systems, publishers, studios, licenses), so scanning 5000 volumes measured at 6-7s against a
+// warm dev catalog, blowing past game-room-web's 5s request timeout. 500 keeps this well under
+// that budget; raise only alongside a real fix (pushing the title match down to a Mongo query
+// instead of an in-memory scan over fully-hydrated volumes).
+const volumeSearchScanLimit = 500
+
+// SearchVolumes finds live volumes whose title contains query (case-insensitive), scanning up to
+// volumeSearchScanLimit volumes - see the comment there for why this doesn't use the shared
+// searchScanLimit other entities' Search* functions use.
 func SearchVolumes(c context.Context, query string) ([]*vo.VolumeVO, error) {
-	all, err := QueryVolumes(c, apiutil.QueryParams{Limit: searchScanLimit})
+	all, err := QueryVolumes(c, apiutil.QueryParams{Limit: volumeSearchScanLimit})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
QueryVolumes resolves each volume's full relation set (systems, publishers, studios, licenses) -
scanning 5000 volumes (the shared `searchScanLimit` other entities' `Search*` functions use)
measured at 6-7s against a warm dev catalog. That exceeds `game-room-web`'s 5s client timeout,
which aborts the connection and crashes the request server-side with a broken-pipe write error
(Sentry CATALOG-API-V, `searchVolumes`).

500 keeps the scan well under that budget. The real fix is pushing the title match down to a
Mongo query instead of scanning fully-hydrated volumes in memory - flagged in the code comment
as follow-up work, not done here given the immediate crash.