### PR TITLE
Store and sync denormalized system titles on volumes

### DIFF
--- a/data/volume.go
+++ b/data/volume.go
@@ -192,7 +192,7 @@ func GetVolume(c context.Context, id string) (*vo.VolumeVO, error) {
 		return nil, err
 	}
 
-	return flattenVolume(c, meta, version, nil), nil
+	return flattenVolume(c, meta, version), nil
 }
 
 // relationIDs extracts each element's ID from a pointer-slice relationship field - the
@@ -209,31 +209,45 @@ func relationIDs[T any](relations []*T, id func(*T) string) []string {
 	return ids
 }
 
-// resolveVolumeRelations resolves a volume's relationship IDs into their VOs. systemsMap, when
-// non-nil, is used as a pre-fetched id->system lookup instead of one game-systems-api call per
-// id - callers resolving many volumes at once (QueryVolumes) build it once via GetSystemsMap and
-// share it across every volume; callers resolving a single volume pass nil and fall back to
-// GetSystem's per-id call, which is cheap enough at that scale.
-func resolveVolumeRelations(c context.Context, systemIds, publisherIds, studioIds, licenseIds []string, systemsMap map[string]*vo.SystemVO) (
-	systems []*vo.SystemVO, publishers []*vo.PublisherVO, studios []*vo.StudioVO, licenses []*vo.LicenseVO,
-) {
-	systems = make([]*vo.SystemVO, 0, len(systemIds))
+// systemsFromTitles builds a volume's system relationship VOs from its denormalized
+// SystemTitles snapshot - no game-systems-api call. A system whose stored title is absent or
+// empty renders its ID as the name (see catalog-volume-detail spec's ID-fallback requirement).
+func systemsFromTitles(systemIds []string, titles map[string]string) []*vo.SystemVO {
+	systems := make([]*vo.SystemVO, 0, len(systemIds))
 	for _, id := range systemIds {
-		if systemsMap != nil {
-			if system, ok := systemsMap[id]; ok {
-				systems = append(systems, system)
-			}
-			continue
+		name := id
+		if t, ok := titles[id]; ok && t != "" {
+			name = t
 		}
-		system, err := GetSystem(c, id)
-		if err != nil {
-			logging.Logger.Error(fmt.Sprintf("No System found from Volume for ID %s: %s", id, err.Error()))
-			continue
-		}
-		if system != nil {
-			systems = append(systems, system)
+		systems = append(systems, &vo.SystemVO{ID: id, GameSystem: name})
+	}
+	return systems
+}
+
+// pruneSystemTitles drops any stored title whose system is no longer referenced, keeping the
+// map parallel to systemIds when a reference is removed on edit.
+func pruneSystemTitles(titles map[string]string, systemIds []string) map[string]string {
+	if len(titles) == 0 {
+		return nil
+	}
+	kept := make(map[string]string, len(systemIds))
+	for _, id := range systemIds {
+		if t, ok := titles[id]; ok && t != "" {
+			kept[id] = t
 		}
 	}
+	if len(kept) == 0 {
+		return nil
+	}
+	return kept
+}
+
+// resolveVolumeRelations resolves a volume's non-system relationship IDs into their VOs. System
+// references are resolved separately from the volume's stored SystemTitles (systemsFromTitles),
+// so this makes no game-systems-api call.
+func resolveVolumeRelations(c context.Context, publisherIds, studioIds, licenseIds []string) (
+	publishers []*vo.PublisherVO, studios []*vo.StudioVO, licenses []*vo.LicenseVO,
+) {
 	publishers = make([]*vo.PublisherVO, 0, len(publisherIds))
 	for _, id := range publisherIds {
 		publisher, err := GetPublisher(c, id)
@@ -273,8 +287,8 @@ func resolveVolumeRelations(c context.Context, systemIds, publisherIds, studioId
 // flattenVolume merges a meta record with its current version into the pre-versioning VolumeVO
 // shape: creation/deletion audit comes from meta, the "last updated" audit comes from the
 // version's own submission audit (its most recent live edit).
-func flattenVolume(c context.Context, meta *models.VolumeMeta, version *models.VolumeVersion, systemsMap map[string]*vo.SystemVO) *vo.VolumeVO {
-	systems, publishers, studios, licenses := resolveVolumeRelations(c, version.SystemIds, version.PublisherIds, version.StudioIds, version.LicenseIds, systemsMap)
+func flattenVolume(c context.Context, meta *models.VolumeMeta, version *models.VolumeVersion) *vo.VolumeVO {
+	publishers, studios, licenses := resolveVolumeRelations(c, version.PublisherIds, version.StudioIds, version.LicenseIds)
 
 	return &vo.VolumeVO{
 		ID:             meta.ID,
@@ -284,7 +298,8 @@ func flattenVolume(c context.Context, meta *models.VolumeMeta, version *models.V
 		Format:         version.Format,
 		CoverAssetId:   version.CoverAssetId,
 		SampleAssetIds: version.SampleAssetIds,
-		Systems:        systems,
+		Systems:        systemsFromTitles(version.SystemIds, version.SystemTitles),
+		SystemTitles:   version.SystemTitles,
 		Publishers:     publishers,
 		Studios:        studios,
 		Licenses:       licenses,
@@ -304,7 +319,7 @@ func flattenVolume(c context.Context, meta *models.VolumeMeta, version *models.V
 // volumeVersionModelToVO converts a version record on its own (no meta) into the version-history
 // API shape, resolving its relationship IDs the same way a flattened read does.
 func volumeVersionModelToVO(c context.Context, version *models.VolumeVersion) *vo.VolumeVersionVO {
-	systems, publishers, studios, licenses := resolveVolumeRelations(c, version.SystemIds, version.PublisherIds, version.StudioIds, version.LicenseIds, nil)
+	publishers, studios, licenses := resolveVolumeRelations(c, version.PublisherIds, version.StudioIds, version.LicenseIds)
 
 	return &vo.VolumeVersionVO{
 		ID:                   version.ID,
@@ -318,7 +333,8 @@ func volumeVersionModelToVO(c context.Context, version *models.VolumeVersion) *v
 		SampleAssetIds:       version.SampleAssetIds,
 		StagedCoverAssetId:   version.StagedCoverAssetId,
 		StagedSampleAssetIds: version.StagedSampleAssetIds,
-		Systems:              systems,
+		Systems:              systemsFromTitles(version.SystemIds, version.SystemTitles),
+		SystemTitles:         version.SystemTitles,
 		Publishers:           publishers,
 		Studios:              studios,
 		Licenses:             licenses,
@@ -349,6 +365,7 @@ func volumeVOToVersionFields(volume *vo.VolumeVO) models.VolumeVersion {
 		Properties:     modelcoreutil.ToPropertyModels(volume.Properties),
 		Tags:           modelcoreutil.ToTagModels(volume.Tags),
 		SystemIds:      relationIDs(volume.Systems, func(s *vo.SystemVO) string { return s.ID }),
+		SystemTitles:   pruneSystemTitles(volume.SystemTitles, relationIDs(volume.Systems, func(s *vo.SystemVO) string { return s.ID })),
 		PublisherIds:   relationIDs(volume.Publishers, func(p *vo.PublisherVO) string { return p.ID }),
 		StudioIds:      relationIDs(volume.Studios, func(s *vo.StudioVO) string { return s.ID }),
 		LicenseIds:     relationIDs(volume.Licenses, func(l *vo.LicenseVO) string { return l.ID }),
@@ -381,15 +398,10 @@ func QueryVolumes(c context.Context, params apiutil.QueryParams) ([]*vo.VolumeVO
 		return nil, err
 	}
 
-	// Resolve every volume's system reference against one shared map instead of one
-	// game-systems-api call per volume - see GetSystemsMap. A page of volumes was measured
-	// taking 10+ seconds under the old per-volume GetSystem calls.
-	systemsMap, err := GetSystemsMap(c)
-	if err != nil {
-		logging.Logger.Error(fmt.Sprintf("Error while fetching systems map for Volumes: %+v", err))
-		systemsMap = map[string]*vo.SystemVO{}
-	}
-
+	// System names come from each volume's denormalized SystemTitles snapshot (see
+	// flattenVolume -> systemsFromTitles), so serving a page of volumes makes no
+	// game-systems-api call. This replaced a per-volume GetSystem fan-out that was measured
+	// taking 10+ seconds for one page.
 	vos := make([]*vo.VolumeVO, 0, len(versions))
 	for _, version := range versions {
 		meta, err := getVolumeMeta(c, version.RecordID)
@@ -404,7 +416,7 @@ func QueryVolumes(c context.Context, params apiutil.QueryParams) ([]*vo.VolumeVO
 		if meta.DeletedAt != nil {
 			continue
 		}
-		vos = append(vos, flattenVolume(c, meta, version, systemsMap))
+		vos = append(vos, flattenVolume(c, meta, version))
 	}
 
 	logging.Logger.Debug("returning volume value objects", "vos", vos)

--- a/data/volume_migration.go
+++ b/data/volume_migration.go
@@ -55,6 +55,7 @@ func MigrateVolumes(c context.Context) (int, error) {
 			CoverAssetId:   v.CoverAssetId,
 			SampleAssetIds: v.SampleAssetIds,
 			SystemIds:      v.SystemIds,
+			SystemTitles:   v.SystemTitles,
 			PublisherIds:   v.PublisherIds,
 			StudioIds:      v.StudioIds,
 			LicenseIds:     v.LicenseIds,

--- a/data/volume_system_titles.go
+++ b/data/volume_system_titles.go
@@ -1,0 +1,74 @@
+package data
+
+import (
+	"context"
+	"strings"
+
+	"github.com/sweetrpg/catalog-objects.go/models"
+	"github.com/sweetrpg/common.go/logging"
+	"github.com/sweetrpg/mongodb.go/database"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// UpdateVolumeSystemTitleBySystem sets the denormalized system title on every live volume
+// version that references systemID, and returns the record IDs of the volumes it changed (for
+// cache invalidation). It is a no-op for volumes whose stored title already equals title, so a
+// redelivered system.updated event makes no further change. A systemID containing "." is
+// skipped and logged - MongoDB forbids "." in a field name, and system_titles is keyed by ID.
+func UpdateVolumeSystemTitleBySystem(c context.Context, systemID, title string) ([]string, error) {
+	if strings.Contains(systemID, ".") {
+		logging.Logger.Error("UpdateVolumeSystemTitleBySystem: system ID contains '.', skipping", "system_id", systemID)
+		return nil, nil
+	}
+
+	coll := database.Db.Collection(volumeVersionCollection)
+	field := "system_titles." + systemID
+
+	// Match only the live versions that reference this system and don't already carry this
+	// exact title - so an unchanged title (idempotent redelivery) touches nothing.
+	filter := bson.D{
+		{Key: "state", Value: string(models.VersionStateLive)},
+		{Key: "system_ids", Value: systemID},
+		{Key: field, Value: bson.D{{Key: "$ne", Value: title}}},
+	}
+
+	cur, err := coll.Find(c, filter, options.Find().SetProjection(bson.D{
+		{Key: "_id", Value: 1}, {Key: "record_id", Value: 1},
+	}))
+	if err != nil {
+		return nil, err
+	}
+	var matched []struct {
+		ID       string `bson:"_id"`
+		RecordID string `bson:"record_id"`
+	}
+	if err := cur.All(c, &matched); err != nil {
+		return nil, err
+	}
+	if len(matched) == 0 {
+		return nil, nil
+	}
+
+	versionIDs := make([]string, len(matched))
+	recordIDs := make([]string, 0, len(matched))
+	seen := make(map[string]struct{}, len(matched))
+	for i, m := range matched {
+		versionIDs[i] = m.ID
+		if _, ok := seen[m.RecordID]; !ok {
+			seen[m.RecordID] = struct{}{}
+			recordIDs = append(recordIDs, m.RecordID)
+		}
+	}
+
+	_, err = coll.UpdateMany(c,
+		bson.D{{Key: "_id", Value: bson.D{{Key: "$in", Value: versionIDs}}}},
+		bson.D{{Key: "$set", Value: bson.D{{Key: field, Value: title}}}},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	logging.Logger.Info("UpdateVolumeSystemTitleBySystem applied", "system_id", systemID, "volumes", len(recordIDs))
+	return recordIDs, nil
+}

--- a/data/volume_system_titles_test.go
+++ b/data/volume_system_titles_test.go
@@ -1,0 +1,149 @@
+package data
+
+import (
+	"github.com/stretchr/testify/assert"
+	apiutil "github.com/sweetrpg/api-core.go/util"
+	"github.com/sweetrpg/catalog-objects.go/models"
+	"github.com/sweetrpg/catalog-objects.go/vo"
+)
+
+func systemRefs(ids ...string) []*vo.SystemVO {
+	refs := make([]*vo.SystemVO, len(ids))
+	for i, id := range ids {
+		refs[i] = &vo.SystemVO{ID: id}
+	}
+	return refs
+}
+
+// 3.2: create with titles -> the stored map and the read VO carry them.
+func (suite *VolumeDataTestSuite) TestAddVolumeStoresSystemTitles() {
+	t := suite.T()
+	id, err := AddVolume(t.Context(), &vo.VolumeVO{
+		Title:        "Titled Systems",
+		Systems:      systemRefs("sysA", "sysB"),
+		SystemTitles: map[string]string{"sysA": "Numenera", "sysB": "The Strange"},
+	})
+	assert.NoError(t, err)
+
+	v, err := GetVolume(t.Context(), *id)
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{"sysA": "Numenera", "sysB": "The Strange"}, v.SystemTitles)
+	names := map[string]string{}
+	for _, s := range v.Systems {
+		names[s.ID] = s.GameSystem
+	}
+	assert.Equal(t, "Numenera", names["sysA"])
+	assert.Equal(t, "The Strange", names["sysB"])
+}
+
+// 3.2: an empty title for a referenced system stores no map entry (renders the ID).
+func (suite *VolumeDataTestSuite) TestAddVolumeEmptyTitleNoMapEntry() {
+	t := suite.T()
+	id, err := AddVolume(t.Context(), &vo.VolumeVO{
+		Title:        "Empty Title",
+		Systems:      systemRefs("sysA"),
+		SystemTitles: map[string]string{"sysA": ""},
+	})
+	assert.NoError(t, err)
+
+	v, err := GetVolume(t.Context(), *id)
+	assert.NoError(t, err)
+	assert.Empty(t, v.SystemTitles["sysA"])
+	assert.Equal(t, "sysA", v.Systems[0].GameSystem, "absent title falls back to the system ID")
+}
+
+// 3.2: editing to swap a system reference drops the removed system's stored title.
+func (suite *VolumeDataTestSuite) TestUpdateVolumeSwapsSystemTitleKeys() {
+	t := suite.T()
+	id, err := AddVolume(t.Context(), &vo.VolumeVO{
+		Title:        "Swap Systems",
+		Systems:      systemRefs("sysA"),
+		SystemTitles: map[string]string{"sysA": "Numenera"},
+	})
+	assert.NoError(t, err)
+
+	_, err = UpdateVolume(t.Context(), *id, &vo.VolumeVO{
+		Title:        "Swap Systems",
+		Systems:      systemRefs("sysB"),
+		SystemTitles: map[string]string{"sysB": "The Strange"},
+	}, models.VersionStateLive)
+	assert.NoError(t, err)
+
+	v, err := GetVolume(t.Context(), *id)
+	assert.NoError(t, err)
+	_, hadOld := v.SystemTitles["sysA"]
+	assert.False(t, hadOld, "removed system's title key should be gone")
+	assert.Equal(t, "The Strange", v.SystemTitles["sysB"])
+}
+
+// 3.4: sets the title on every live volume referencing the system, leaves others untouched,
+// returns the affected record IDs, and is a no-op on a second identical call.
+func (suite *VolumeDataTestSuite) TestUpdateVolumeSystemTitleBySystem() {
+	t := suite.T()
+	a, err := AddVolume(t.Context(), &vo.VolumeVO{Title: "Refs sysX #1", Systems: systemRefs("sysX"), SystemTitles: map[string]string{"sysX": "Old"}})
+	assert.NoError(t, err)
+	b, err := AddVolume(t.Context(), &vo.VolumeVO{Title: "Refs sysX #2", Systems: systemRefs("sysX"), SystemTitles: map[string]string{"sysX": "Old"}})
+	assert.NoError(t, err)
+	c, err := AddVolume(t.Context(), &vo.VolumeVO{Title: "Refs sysY", Systems: systemRefs("sysY"), SystemTitles: map[string]string{"sysY": "Other"}})
+	assert.NoError(t, err)
+
+	changed, err := UpdateVolumeSystemTitleBySystem(t.Context(), "sysX", "New Name")
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, []string{*a, *b}, changed)
+
+	va, _ := GetVolume(t.Context(), *a)
+	vb, _ := GetVolume(t.Context(), *b)
+	vc, _ := GetVolume(t.Context(), *c)
+	assert.Equal(t, "New Name", va.SystemTitles["sysX"])
+	assert.Equal(t, "New Name", vb.SystemTitles["sysX"])
+	assert.Equal(t, "Other", vc.SystemTitles["sysY"], "unrelated volume untouched")
+
+	again, err := UpdateVolumeSystemTitleBySystem(t.Context(), "sysX", "New Name")
+	assert.NoError(t, err)
+	assert.Empty(t, again, "redelivered event with the same title is a no-op")
+}
+
+// 3.4: no matching volumes -> nothing changed, no error.
+func (suite *VolumeDataTestSuite) TestUpdateVolumeSystemTitleBySystemNoMatches() {
+	t := suite.T()
+	changed, err := UpdateVolumeSystemTitleBySystem(t.Context(), "system-nobody-references", "Whatever")
+	assert.NoError(t, err)
+	assert.Empty(t, changed)
+}
+
+// 3.4: a system ID containing "." is skipped (MongoDB forbids "." in field names).
+func (suite *VolumeDataTestSuite) TestUpdateVolumeSystemTitleBySystemDottedIDSkipped() {
+	t := suite.T()
+	id, err := AddVolume(t.Context(), &vo.VolumeVO{Title: "Dotted", Systems: systemRefs("a.b"), SystemTitles: map[string]string{}})
+	assert.NoError(t, err)
+
+	changed, err := UpdateVolumeSystemTitleBySystem(t.Context(), "a.b", "Nope")
+	assert.NoError(t, err)
+	assert.Empty(t, changed)
+
+	v, _ := GetVolume(t.Context(), *id)
+	assert.Empty(t, v.SystemTitles["a.b"])
+}
+
+// 3.3: a volume list read renders system names from stored titles with no game-systems-api
+// client configured (GameSystemsClient stays nil in tests).
+func (suite *VolumeDataTestSuite) TestQueryVolumesUsesStoredSystemTitles() {
+	t := suite.T()
+	_, err := AddVolume(t.Context(), &vo.VolumeVO{
+		Title:        "In The List",
+		Systems:      systemRefs("sysL"),
+		SystemTitles: map[string]string{"sysL": "Listed System"},
+	})
+	assert.NoError(t, err)
+
+	results, err := QueryVolumes(t.Context(), apiutil.QueryParams{Limit: 200})
+	assert.NoError(t, err)
+	var seen bool
+	for _, v := range results {
+		if v.Title == "In The List" {
+			seen = true
+			assert.Equal(t, "Listed System", v.Systems[0].GameSystem)
+		}
+	}
+	assert.True(t, seen, "the seeded volume should be in the list")
+}

--- a/data/volume_versioning.go
+++ b/data/volume_versioning.go
@@ -134,7 +134,7 @@ func GetVolumeVersion(c context.Context, id string, version int) (*vo.VolumeVers
 // selectively accept - everything on VolumeVersion except its version-lifecycle bookkeeping.
 var volumeVersionSubstantiveFields = []string{
 	"title", "description", "notes", "format", "cover_asset_id", "sample_asset_ids",
-	"system_ids", "publisher_ids", "studio_ids", "license_ids", "properties", "tags",
+	"system_ids", "system_titles", "publisher_ids", "studio_ids", "license_ids", "properties", "tags",
 }
 
 func volumeVersionFieldValue(v *models.VolumeVersion, field string) any {
@@ -153,6 +153,8 @@ func volumeVersionFieldValue(v *models.VolumeVersion, field string) any {
 		return v.SampleAssetIds
 	case "system_ids":
 		return v.SystemIds
+	case "system_titles":
+		return v.SystemTitles
 	case "publisher_ids":
 		return v.PublisherIds
 	case "studio_ids":
@@ -184,6 +186,8 @@ func setVolumeVersionFieldValue(v *models.VolumeVersion, field string, value any
 		v.SampleAssetIds = value.([]string)
 	case "system_ids":
 		v.SystemIds = value.([]string)
+	case "system_titles":
+		v.SystemTitles, _ = value.(map[string]string)
 	case "publisher_ids":
 		v.PublisherIds = value.([]string)
 	case "studio_ids":

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.5
 require (
 	github.com/stretchr/testify v1.12.1
 	github.com/sweetrpg/api-core.go v0.1.1
-	github.com/sweetrpg/catalog-objects.go v0.4.4-0.20260902173540-c581010f22c1
+	github.com/sweetrpg/catalog-objects.go v0.5.0
 	github.com/sweetrpg/common.go v0.0.16
 	github.com/sweetrpg/model-core.go v0.0.173
 	github.com/sweetrpg/mongodb.go v0.0.193

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.5
 require (
 	github.com/stretchr/testify v1.12.1
 	github.com/sweetrpg/api-core.go v0.1.1
-	github.com/sweetrpg/catalog-objects.go v0.4.3
+	github.com/sweetrpg/catalog-objects.go v0.4.4-0.20260902173540-c581010f22c1
 	github.com/sweetrpg/common.go v0.0.16
 	github.com/sweetrpg/model-core.go v0.0.173
 	github.com/sweetrpg/mongodb.go v0.0.193

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,8 @@ github.com/stretchr/testify v1.12.1 h1:EuwCh5fleGS7H32xRwO3wRGT7DxrDhLAT6FF8MpWD
 github.com/stretchr/testify v1.12.1/go.mod h1:MDEgiDPPsNp5cuIrHPPCyornHKgEVbtFUmoNlxoYthg=
 github.com/sweetrpg/api-core.go v0.1.1 h1:qqr5Rgiaw7n2RtDZ7fdoy5vw8RT3L42orhJ/x+EYX9w=
 github.com/sweetrpg/api-core.go v0.1.1/go.mod h1:ka2gLYUlukRaBXiaaohfRSHoNH77oSrTkkik07Z+lj0=
-github.com/sweetrpg/catalog-objects.go v0.4.4-0.20260902173540-c581010f22c1 h1:Mnraq/JE2Mo3zkWi08ulwnk3Q23riYVayRNEP5Kt3yg=
-github.com/sweetrpg/catalog-objects.go v0.4.4-0.20260902173540-c581010f22c1/go.mod h1:qwB2oluVsq8WSdnZHQTAZ5Z3ZeYrLkimVZPT/jilDs4=
+github.com/sweetrpg/catalog-objects.go v0.5.0 h1:v5yyLUHbQ1wQ7r5CjKo/nBazKjDZVEaSjoHaj2l0EcA=
+github.com/sweetrpg/catalog-objects.go v0.5.0/go.mod h1:qwB2oluVsq8WSdnZHQTAZ5Z3ZeYrLkimVZPT/jilDs4=
 github.com/sweetrpg/common.go v0.0.16 h1:XT8PwUXz0BOMIITXLjw3G6rEjjRUEs0Xs4+R9o2fVBk=
 github.com/sweetrpg/common.go v0.0.16/go.mod h1:PVpjDIeB/bZYJZk5fc8whuqVJE8K5k/DsO3o+aZFEcE=
 github.com/sweetrpg/model-core.go v0.0.173 h1:mIZ4z0ETkCH7I3Az0jwTFOyh66OTm7Z4/f0Rx/w+5Fk=

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,8 @@ github.com/stretchr/testify v1.12.1 h1:EuwCh5fleGS7H32xRwO3wRGT7DxrDhLAT6FF8MpWD
 github.com/stretchr/testify v1.12.1/go.mod h1:MDEgiDPPsNp5cuIrHPPCyornHKgEVbtFUmoNlxoYthg=
 github.com/sweetrpg/api-core.go v0.1.1 h1:qqr5Rgiaw7n2RtDZ7fdoy5vw8RT3L42orhJ/x+EYX9w=
 github.com/sweetrpg/api-core.go v0.1.1/go.mod h1:ka2gLYUlukRaBXiaaohfRSHoNH77oSrTkkik07Z+lj0=
-github.com/sweetrpg/catalog-objects.go v0.4.3 h1:WukLXUnpMCXyuthx8PVPu3FvqtTCJvjorA5Dwt3vMvw=
-github.com/sweetrpg/catalog-objects.go v0.4.3/go.mod h1:94LMLsDebNMb629Nv+FHkKq+FI6H8CeCbeDl9RWs2O0=
+github.com/sweetrpg/catalog-objects.go v0.4.4-0.20260902173540-c581010f22c1 h1:Mnraq/JE2Mo3zkWi08ulwnk3Q23riYVayRNEP5Kt3yg=
+github.com/sweetrpg/catalog-objects.go v0.4.4-0.20260902173540-c581010f22c1/go.mod h1:qwB2oluVsq8WSdnZHQTAZ5Z3ZeYrLkimVZPT/jilDs4=
 github.com/sweetrpg/common.go v0.0.16 h1:XT8PwUXz0BOMIITXLjw3G6rEjjRUEs0Xs4+R9o2fVBk=
 github.com/sweetrpg/common.go v0.0.16/go.mod h1:PVpjDIeB/bZYJZk5fc8whuqVJE8K5k/DsO3o+aZFEcE=
 github.com/sweetrpg/model-core.go v0.0.173 h1:mIZ4z0ETkCH7I3Az0jwTFOyh66OTm7Z4/f0Rx/w+5Fk=


### PR DESCRIPTION
Tasks 3.2-3.4 of `denorm-system-title-volumes` (sweetrpg/platform#84).

## Changes

- `volumeVOToVersionFields` persists `VolumeVO.SystemTitles`, pruned to referenced systems (a removed reference drops its key).
- Volume read builders render the system relationship from the stored `SystemTitles` snapshot with an ID fallback and pass the map through to the VO. Removes the per-row `game-systems-api` fan-out from `GetVolume` / `QueryVolumes` (task 4.3, done here since the file lives in this repo). `GetSystem` / `QuerySystems` / `GetSystemsMap` stay - catalog-api's `/systems` routes still use them.
- `UpdateVolumeSystemTitleBySystem(ctx, systemID, title) ([]string, error)`: `$set system_titles.<systemID>` on every live volume version referencing `systemID`, returns affected record IDs, no-op when unchanged (idempotent), skips a `systemID` containing `.`.
- `system_titles` rides with `system_ids` through the version field accessors and the pre-versioning migration.

## Verify

`go build/vet/test ./...` green (data suite against a local `mongo:7`). Tests cover create-with-titles round trip, empty title -> ID fallback, edit swaps title keys, bulk update across two of three volumes with correct affected IDs + idempotent second call, no-match, dotted-ID skip, list read renders stored titles with no client configured.

## Chained dependency

`go.mod` pins `catalog-objects.go` to the `69-volume-system-titles` branch pseudo-version (sweetrpg/catalog-objects.go#70). Re-pin to the tagged `catalog-objects.go` release before merging.

Closes #70
Refs sweetrpg/platform#84