### PR TITLE
Stamp updated_at/updated_by on meta mutations, soft delete, and creates

### DIFF
--- a/data/entity_versioning.go
+++ b/data/entity_versioning.go
@@ -156,11 +156,15 @@ func (cfg entityVersioningConfig[T]) archiveVersion(c context.Context, recordID 
 	return cfg.setVersionState(c, recordID, version, bson.D{{Key: "state", Value: string(models.VersionStateArchived)}})
 }
 
-func (cfg entityVersioningConfig[T]) setMetaCurrentVersion(c context.Context, recordID string, version int) error {
+func (cfg entityVersioningConfig[T]) setMetaCurrentVersion(c context.Context, recordID string, version int, actingUserID string) error {
 	_, err := database.Db.Collection(cfg.metaCollection).UpdateOne(
 		c,
 		bson.D{{Key: "_id", Value: recordID}},
-		bson.D{{Key: "$set", Value: bson.D{{Key: "current_version", Value: version}}}},
+		bson.D{{Key: "$set", Value: bson.D{
+			{Key: "current_version", Value: version},
+			{Key: "updated_at", Value: time.Now()},
+			{Key: "updated_by", Value: actingUserID},
+		}}},
 	)
 	return err
 }
@@ -202,7 +206,10 @@ func (cfg entityVersioningConfig[T]) changedFields(submitted, base *T) []string 
 func (cfg entityVersioningConfig[T]) addEntity(c context.Context, entity *T, createdBy string) (*string, error) {
 	now := time.Now()
 	metaID := primitive.NewObjectID().Hex()
-	meta := models.EntityMeta{ID: metaID, CurrentVersion: 1, CreatedAt: now, CreatedBy: createdBy}
+	meta := models.EntityMeta{
+		ID: metaID, CurrentVersion: 1,
+		CreatedAt: now, CreatedBy: createdBy, UpdatedAt: now, UpdatedBy: createdBy,
+	}
 	if _, err := database.Insert[models.EntityMeta](cfg.metaCollection, meta); err != nil {
 		return nil, err
 	}
@@ -264,7 +271,7 @@ func (cfg entityVersioningConfig[T]) createVersionWithSubmission(c context.Conte
 		if err := cfg.archiveVersion(c, id, meta.CurrentVersion); err != nil {
 			return nil, err
 		}
-		if err := cfg.setMetaCurrentVersion(c, id, nextVersion); err != nil {
+		if err := cfg.setMetaCurrentVersion(c, id, nextVersion, submittedBy); err != nil {
 			return nil, err
 		}
 	}
@@ -347,7 +354,7 @@ func (cfg entityVersioningConfig[T]) acceptVersion(c context.Context, id string,
 		}); err != nil {
 			return nil, nil, err
 		}
-		if err := cfg.setMetaCurrentVersion(c, id, version); err != nil {
+		if err := cfg.setMetaCurrentVersion(c, id, version, reviewedBy); err != nil {
 			return nil, nil, err
 		}
 		return submitted, nil, nil
@@ -412,7 +419,7 @@ func (cfg entityVersioningConfig[T]) acceptVersion(c context.Context, id string,
 	if err := cfg.archiveVersion(c, id, meta.CurrentVersion); err != nil {
 		return nil, nil, err
 	}
-	if err := cfg.setMetaCurrentVersion(c, id, nextVersion); err != nil {
+	if err := cfg.setMetaCurrentVersion(c, id, nextVersion, reviewedBy); err != nil {
 		return nil, nil, err
 	}
 	if err := cfg.setVersionState(c, id, version, bson.D{
@@ -474,7 +481,7 @@ func (cfg entityVersioningConfig[T]) retractVersion(c context.Context, id string
 }
 
 // setCurrentVersion rolls a record back (or forward) to an arbitrary existing version.
-func (cfg entityVersioningConfig[T]) setCurrentVersion(c context.Context, id string, version int) (*T, error) {
+func (cfg entityVersioningConfig[T]) setCurrentVersion(c context.Context, id string, version int, actingUserID string) (*T, error) {
 	meta, err := cfg.getMeta(c, id)
 	if err != nil {
 		return nil, err
@@ -498,7 +505,7 @@ func (cfg entityVersioningConfig[T]) setCurrentVersion(c context.Context, id str
 	if err := cfg.setVersionState(c, id, version, bson.D{{Key: "state", Value: string(models.VersionStateLive)}}); err != nil {
 		return nil, err
 	}
-	if err := cfg.setMetaCurrentVersion(c, id, version); err != nil {
+	if err := cfg.setMetaCurrentVersion(c, id, version, actingUserID); err != nil {
 		return nil, err
 	}
 	cfg.lifecycle(target).State = models.VersionStateLive
@@ -513,17 +520,24 @@ func (cfg entityVersioningConfig[T]) softDelete(c context.Context, id string, de
 	_, err := database.Db.Collection(cfg.metaCollection).UpdateOne(
 		c,
 		bson.D{{Key: "_id", Value: id}},
-		bson.D{{Key: "$set", Value: bson.D{{Key: "deleted_at", Value: now}, {Key: "deleted_by", Value: deletedBy}}}},
+		bson.D{{Key: "$set", Value: bson.D{
+			{Key: "deleted_at", Value: now}, {Key: "deleted_by", Value: deletedBy},
+			{Key: "updated_at", Value: now}, {Key: "updated_by", Value: deletedBy},
+		}}},
 	)
 	return err
 }
 
 // restore clears the meta record's deleted_at/deleted_by, returning it to every normal read path.
-func (cfg entityVersioningConfig[T]) restore(c context.Context, id string) error {
+func (cfg entityVersioningConfig[T]) restore(c context.Context, id string, restoredBy string) error {
+	now := time.Now()
 	_, err := database.Db.Collection(cfg.metaCollection).UpdateOne(
 		c,
 		bson.D{{Key: "_id", Value: id}},
-		bson.D{{Key: "$set", Value: bson.D{{Key: "deleted_at", Value: nil}, {Key: "deleted_by", Value: nil}}}},
+		bson.D{{Key: "$set", Value: bson.D{
+			{Key: "deleted_at", Value: nil}, {Key: "deleted_by", Value: nil},
+			{Key: "updated_at", Value: now}, {Key: "updated_by", Value: restoredBy},
+		}}},
 	)
 	return err
 }
@@ -571,7 +585,9 @@ func migrateEntity[Old any, New any](c context.Context, cfg migrationConfig[Old,
 
 		aud := cfg.auditable(old)
 		meta := models.EntityMeta{
-			ID: id, CurrentVersion: 1, CreatedAt: aud.CreatedAt, CreatedBy: aud.CreatedBy,
+			ID: id, CurrentVersion: 1,
+			CreatedAt: aud.CreatedAt, CreatedBy: aud.CreatedBy,
+			UpdatedAt: aud.UpdatedAt, UpdatedBy: aud.UpdatedBy,
 			DeletedAt: aud.DeletedAt, DeletedBy: aud.DeletedBy,
 		}
 		if _, err := database.Insert[models.EntityMeta](cfg.versioning.metaCollection, meta); err != nil {

--- a/data/license_versioning.go
+++ b/data/license_versioning.go
@@ -59,8 +59,8 @@ func SoftDeleteLicense(c context.Context, id string, deletedBy string) error {
 }
 
 // RestoreLicense clears a soft-deleted license's deletion, returning it to every normal read path.
-func RestoreLicense(c context.Context, id string) error {
-	return licenseVersioning.restore(c, id)
+func RestoreLicense(c context.Context, id string, restoredBy string) error {
+	return licenseVersioning.restore(c, id, restoredBy)
 }
 
 func licenseVersionToVO(version *models.LicenseVersion) *vo.LicenseVersionVO {
@@ -99,7 +99,7 @@ func flattenLicense(meta *models.EntityMeta, version *models.LicenseVersion) *vo
 		Tags:       modelcoreutil.FromTagModels(version.Tags),
 		AuditableVO: modelcorevo.AuditableVO{
 			CreatedAt: meta.CreatedAt, CreatedBy: meta.CreatedBy,
-			UpdatedAt: version.SubmittedAt, UpdatedBy: version.SubmittedBy,
+			UpdatedAt: meta.UpdatedAt, UpdatedBy: meta.UpdatedBy,
 			DeletedAt: meta.DeletedAt, DeletedBy: meta.DeletedBy,
 		},
 	}
@@ -186,8 +186,8 @@ func RetractLicenseVersion(c context.Context, id string, version int, submitterI
 }
 
 // SetCurrentLicenseVersion rolls a license back (or forward) to an arbitrary existing version.
-func SetCurrentLicenseVersion(c context.Context, id string, version int) (*vo.LicenseVersionVO, error) {
-	result, err := licenseVersioning.setCurrentVersion(c, id, version)
+func SetCurrentLicenseVersion(c context.Context, id string, version int, actingUserID string) (*vo.LicenseVersionVO, error) {
+	result, err := licenseVersioning.setCurrentVersion(c, id, version, actingUserID)
 	if err != nil || result == nil {
 		return nil, err
 	}

--- a/data/person_versioning.go
+++ b/data/person_versioning.go
@@ -51,8 +51,8 @@ func SoftDeletePerson(c context.Context, id string, deletedBy string) error {
 }
 
 // RestorePerson clears a soft-deleted person's deletion, returning it to every normal read path.
-func RestorePerson(c context.Context, id string) error {
-	return personVersioning.restore(c, id)
+func RestorePerson(c context.Context, id string, restoredBy string) error {
+	return personVersioning.restore(c, id, restoredBy)
 }
 
 func personVersionToVO(version *models.PersonVersion) *vo.PersonVersionVO {
@@ -85,7 +85,7 @@ func flattenPerson(meta *models.EntityMeta, version *models.PersonVersion) *vo.P
 		Tags:       modelcoreutil.FromTagModels(version.Tags),
 		AuditableVO: modelcorevo.AuditableVO{
 			CreatedAt: meta.CreatedAt, CreatedBy: meta.CreatedBy,
-			UpdatedAt: version.SubmittedAt, UpdatedBy: version.SubmittedBy,
+			UpdatedAt: meta.UpdatedAt, UpdatedBy: meta.UpdatedBy,
 			DeletedAt: meta.DeletedAt, DeletedBy: meta.DeletedBy,
 		},
 	}
@@ -172,8 +172,8 @@ func RetractPersonVersion(c context.Context, id string, version int, submitterID
 }
 
 // SetCurrentPersonVersion rolls a person back (or forward) to an arbitrary existing version.
-func SetCurrentPersonVersion(c context.Context, id string, version int) (*vo.PersonVersionVO, error) {
-	result, err := personVersioning.setCurrentVersion(c, id, version)
+func SetCurrentPersonVersion(c context.Context, id string, version int, actingUserID string) (*vo.PersonVersionVO, error) {
+	result, err := personVersioning.setCurrentVersion(c, id, version, actingUserID)
 	if err != nil || result == nil {
 		return nil, err
 	}

--- a/data/publisher_test.go
+++ b/data/publisher_test.go
@@ -136,7 +136,7 @@ func (suite *PublisherDataTestSuite) TestSetCurrentPublisherVersion() {
 	}, models.VersionStateLive)
 	assert.NoError(suite.T(), err)
 
-	rolledBack, err := SetCurrentPublisherVersion(suite.T().Context(), suite.seedPublisherID, 1)
+	rolledBack, err := SetCurrentPublisherVersion(suite.T().Context(), suite.seedPublisherID, 1, "test-reviewer")
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), "Test Publisher", rolledBack.Name)
 
@@ -182,7 +182,7 @@ func (suite *PublisherDataTestSuite) TestSoftDeletePublisherLifecycle() {
 	assert.NotNil(suite.T(), fetched.DeletedAt)
 	assert.Equal(suite.T(), "admin-1", *fetched.DeletedBy)
 
-	err = RestorePublisher(suite.T().Context(), suite.seedPublisherID)
+	err = RestorePublisher(suite.T().Context(), suite.seedPublisherID, "test-restorer")
 	assert.NoError(suite.T(), err)
 
 	restored, err := GetPublisher(suite.T().Context(), suite.seedPublisherID)

--- a/data/publisher_versioning.go
+++ b/data/publisher_versioning.go
@@ -55,8 +55,8 @@ func SoftDeletePublisher(c context.Context, id string, deletedBy string) error {
 
 // RestorePublisher clears a soft-deleted publisher's deletion, returning it to every normal read
 // path.
-func RestorePublisher(c context.Context, id string) error {
-	return publisherVersioning.restore(c, id)
+func RestorePublisher(c context.Context, id string, restoredBy string) error {
+	return publisherVersioning.restore(c, id, restoredBy)
 }
 
 func publisherVersionToVO(version *models.PublisherVersion) *vo.PublisherVersionVO {
@@ -89,7 +89,7 @@ func flattenPublisher(meta *models.EntityMeta, version *models.PublisherVersion)
 		Tags:       modelcoreutil.FromTagModels(version.Tags),
 		AuditableVO: modelcorevo.AuditableVO{
 			CreatedAt: meta.CreatedAt, CreatedBy: meta.CreatedBy,
-			UpdatedAt: version.SubmittedAt, UpdatedBy: version.SubmittedBy,
+			UpdatedAt: meta.UpdatedAt, UpdatedBy: meta.UpdatedBy,
 			DeletedAt: meta.DeletedAt, DeletedBy: meta.DeletedBy,
 		},
 	}
@@ -179,8 +179,8 @@ func RetractPublisherVersion(c context.Context, id string, version int, submitte
 }
 
 // SetCurrentPublisherVersion rolls a publisher back (or forward) to an arbitrary existing version.
-func SetCurrentPublisherVersion(c context.Context, id string, version int) (*vo.PublisherVersionVO, error) {
-	result, err := publisherVersioning.setCurrentVersion(c, id, version)
+func SetCurrentPublisherVersion(c context.Context, id string, version int, actingUserID string) (*vo.PublisherVersionVO, error) {
+	result, err := publisherVersioning.setCurrentVersion(c, id, version, actingUserID)
 	if err != nil || result == nil {
 		return nil, err
 	}

--- a/data/studio_versioning.go
+++ b/data/studio_versioning.go
@@ -53,8 +53,8 @@ func SoftDeleteStudio(c context.Context, id string, deletedBy string) error {
 }
 
 // RestoreStudio clears a soft-deleted studio's deletion, returning it to every normal read path.
-func RestoreStudio(c context.Context, id string) error {
-	return studioVersioning.restore(c, id)
+func RestoreStudio(c context.Context, id string, restoredBy string) error {
+	return studioVersioning.restore(c, id, restoredBy)
 }
 
 func studioVersionToVO(version *models.StudioVersion) *vo.StudioVersionVO {
@@ -87,7 +87,7 @@ func flattenStudio(meta *models.EntityMeta, version *models.StudioVersion) *vo.S
 		Tags:       modelcoreutil.FromTagModels(version.Tags),
 		AuditableVO: modelcorevo.AuditableVO{
 			CreatedAt: meta.CreatedAt, CreatedBy: meta.CreatedBy,
-			UpdatedAt: version.SubmittedAt, UpdatedBy: version.SubmittedBy,
+			UpdatedAt: meta.UpdatedAt, UpdatedBy: meta.UpdatedBy,
 			DeletedAt: meta.DeletedAt, DeletedBy: meta.DeletedBy,
 		},
 	}
@@ -174,8 +174,8 @@ func RetractStudioVersion(c context.Context, id string, version int, submitterID
 }
 
 // SetCurrentStudioVersion rolls a studio back (or forward) to an arbitrary existing version.
-func SetCurrentStudioVersion(c context.Context, id string, version int) (*vo.StudioVersionVO, error) {
-	result, err := studioVersioning.setCurrentVersion(c, id, version)
+func SetCurrentStudioVersion(c context.Context, id string, version int, actingUserID string) (*vo.StudioVersionVO, error) {
+	result, err := studioVersioning.setCurrentVersion(c, id, version, actingUserID)
 	if err != nil || result == nil {
 		return nil, err
 	}

--- a/data/system_client.go
+++ b/data/system_client.go
@@ -33,7 +33,7 @@ func GetSystem(c context.Context, id string) (*vo.SystemVO, error) {
 		Tags: system.Tags,
 		AuditableVO: modelcorevo.AuditableVO{
 			CreatedAt: system.CreatedAt, CreatedBy: system.CreatedBy,
-			UpdatedAt: system.CreatedAt, UpdatedBy: system.CreatedBy,
+			UpdatedAt: system.UpdatedAt, UpdatedBy: system.UpdatedBy,
 		},
 	}, nil
 }
@@ -56,7 +56,7 @@ func QuerySystems(c context.Context) ([]*vo.SystemVO, error) {
 			Tags: system.Tags,
 			AuditableVO: modelcorevo.AuditableVO{
 				CreatedAt: system.CreatedAt, CreatedBy: system.CreatedBy,
-				UpdatedAt: system.CreatedAt, UpdatedBy: system.CreatedBy,
+				UpdatedAt: system.UpdatedAt, UpdatedBy: system.UpdatedBy,
 			},
 		}
 	}
@@ -100,7 +100,7 @@ func GetSystemsMap(c context.Context) (map[string]*vo.SystemVO, error) {
 			Tags: system.Tags,
 			AuditableVO: modelcorevo.AuditableVO{
 				CreatedAt: system.CreatedAt, CreatedBy: system.CreatedBy,
-				UpdatedAt: system.CreatedAt, UpdatedBy: system.CreatedBy,
+				UpdatedAt: system.UpdatedAt, UpdatedBy: system.UpdatedBy,
 			},
 		}
 	}

--- a/data/volume.go
+++ b/data/volume.go
@@ -35,6 +35,8 @@ func AddVolume(c context.Context, volume *vo.VolumeVO) (*string, error) {
 		CurrentVersion: 1,
 		CreatedAt:      now,
 		CreatedBy:      volume.CreatedBy,
+		UpdatedAt:      now,
+		UpdatedBy:      volume.CreatedBy,
 	}
 	if _, err := database.Insert[models.VolumeMeta](volumeMetaCollection, meta); err != nil {
 		logging.Logger.Error("Error while inserting VolumeMeta object", "error", err)
@@ -124,7 +126,7 @@ func createVolumeVersion(c context.Context, id string, volume *vo.VolumeVO, stat
 		if err := archiveVolumeVersion(c, id, meta.CurrentVersion); err != nil {
 			return nil, err
 		}
-		if err := setVolumeMetaCurrentVersion(c, id, nextVersion); err != nil {
+		if err := setVolumeMetaCurrentVersion(c, id, nextVersion, submittedBy); err != nil {
 			return nil, err
 		}
 	}
@@ -150,17 +152,24 @@ func SoftDeleteVolume(c context.Context, id string, deletedBy string) error {
 	_, err := database.Db.Collection(volumeMetaCollection).UpdateOne(
 		c,
 		bson.D{{Key: "_id", Value: id}},
-		bson.D{{Key: "$set", Value: bson.D{{Key: "deleted_at", Value: now}, {Key: "deleted_by", Value: deletedBy}}}},
+		bson.D{{Key: "$set", Value: bson.D{
+			{Key: "deleted_at", Value: now}, {Key: "deleted_by", Value: deletedBy},
+			{Key: "updated_at", Value: now}, {Key: "updated_by", Value: deletedBy},
+		}}},
 	)
 	return err
 }
 
 // RestoreVolume clears a soft-deleted volume's deletion, returning it to QueryVolumes.
-func RestoreVolume(c context.Context, id string) error {
+func RestoreVolume(c context.Context, id string, restoredBy string) error {
+	now := time.Now()
 	_, err := database.Db.Collection(volumeMetaCollection).UpdateOne(
 		c,
 		bson.D{{Key: "_id", Value: id}},
-		bson.D{{Key: "$set", Value: bson.D{{Key: "deleted_at", Value: nil}, {Key: "deleted_by", Value: nil}}}},
+		bson.D{{Key: "$set", Value: bson.D{
+			{Key: "deleted_at", Value: nil}, {Key: "deleted_by", Value: nil},
+			{Key: "updated_at", Value: now}, {Key: "updated_by", Value: restoredBy},
+		}}},
 	)
 	return err
 }
@@ -285,8 +294,9 @@ func resolveVolumeRelations(c context.Context, publisherIds, studioIds, licenseI
 }
 
 // flattenVolume merges a meta record with its current version into the pre-versioning VolumeVO
-// shape: creation/deletion audit comes from meta, the "last updated" audit comes from the
-// version's own submission audit (its most recent live edit).
+// shape. The full audit block (created/updated/deleted) comes from the meta record - the stable
+// record's own audit trail, stamped whenever its current-version pointer moves or it is
+// soft-deleted (PADR-0001).
 func flattenVolume(c context.Context, meta *models.VolumeMeta, version *models.VolumeVersion) *vo.VolumeVO {
 	publishers, studios, licenses := resolveVolumeRelations(c, version.PublisherIds, version.StudioIds, version.LicenseIds)
 
@@ -308,8 +318,8 @@ func flattenVolume(c context.Context, meta *models.VolumeMeta, version *models.V
 		AuditableVO: modelcorevo.AuditableVO{
 			CreatedAt: meta.CreatedAt,
 			CreatedBy: meta.CreatedBy,
-			UpdatedAt: version.SubmittedAt,
-			UpdatedBy: version.SubmittedBy,
+			UpdatedAt: meta.UpdatedAt,
+			UpdatedBy: meta.UpdatedBy,
 			DeletedAt: meta.DeletedAt,
 			DeletedBy: meta.DeletedBy,
 		},

--- a/data/volume_migration.go
+++ b/data/volume_migration.go
@@ -36,6 +36,8 @@ func MigrateVolumes(c context.Context) (int, error) {
 			CurrentVersion: 1,
 			CreatedAt:      v.CreatedAt,
 			CreatedBy:      v.CreatedBy,
+			UpdatedAt:      v.UpdatedAt,
+			UpdatedBy:      v.UpdatedBy,
 			DeletedAt:      v.DeletedAt,
 			DeletedBy:      v.DeletedBy,
 		}

--- a/data/volume_test.go
+++ b/data/volume_test.go
@@ -366,7 +366,7 @@ func (suite *VolumeDataTestSuite) TestSetCurrentVolumeVersionRollback() {
 	}, models.VersionStateLive)
 	assert.NoError(suite.T(), err)
 
-	restored, err := SetCurrentVolumeVersion(suite.T().Context(), suite.seedVolumeID, 1)
+	restored, err := SetCurrentVolumeVersion(suite.T().Context(), suite.seedVolumeID, 1, "test-reviewer")
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), models.VersionStateLive, models.VersionState(restored.State))
 
@@ -395,7 +395,7 @@ func (suite *VolumeDataTestSuite) TestSoftDeleteVolumeLifecycle() {
 	assert.NotNil(suite.T(), fetched.DeletedAt)
 	assert.Equal(suite.T(), "admin-1", *fetched.DeletedBy)
 
-	err = RestoreVolume(suite.T().Context(), suite.seedVolumeID)
+	err = RestoreVolume(suite.T().Context(), suite.seedVolumeID, "test-restorer")
 	assert.NoError(suite.T(), err)
 
 	restored, err := GetVolume(suite.T().Context(), suite.seedVolumeID)

--- a/data/volume_versioning.go
+++ b/data/volume_versioning.go
@@ -91,11 +91,15 @@ func archiveVolumeVersion(c context.Context, recordID string, version int) error
 	return setVolumeVersionState(c, recordID, version, bson.D{{Key: "state", Value: string(models.VersionStateArchived)}})
 }
 
-func setVolumeMetaCurrentVersion(c context.Context, recordID string, version int) error {
+func setVolumeMetaCurrentVersion(c context.Context, recordID string, version int, actingUserID string) error {
 	_, err := database.Db.Collection(volumeMetaCollection).UpdateOne(
 		c,
 		bson.D{{Key: "_id", Value: recordID}},
-		bson.D{{Key: "$set", Value: bson.D{{Key: "current_version", Value: version}}}},
+		bson.D{{Key: "$set", Value: bson.D{
+			{Key: "current_version", Value: version},
+			{Key: "updated_at", Value: time.Now()},
+			{Key: "updated_by", Value: actingUserID},
+		}}},
 	)
 	return err
 }
@@ -305,7 +309,7 @@ func AcceptVolumeVersion(c context.Context, id string, version int, selectedFiel
 		if err := setVolumeVersionState(c, id, version, update); err != nil {
 			return nil, nil, err
 		}
-		if err := setVolumeMetaCurrentVersion(c, id, version); err != nil {
+		if err := setVolumeMetaCurrentVersion(c, id, version, reviewedBy); err != nil {
 			return nil, nil, err
 		}
 		return volumeVersionModelToVO(c, submitted), nil, nil
@@ -369,7 +373,7 @@ func AcceptVolumeVersion(c context.Context, id string, version int, selectedFiel
 	if err := archiveVolumeVersion(c, id, meta.CurrentVersion); err != nil {
 		return nil, nil, err
 	}
-	if err := setVolumeMetaCurrentVersion(c, id, nextVersion); err != nil {
+	if err := setVolumeMetaCurrentVersion(c, id, nextVersion, reviewedBy); err != nil {
 		return nil, nil, err
 	}
 	if err := setVolumeVersionState(c, id, version, bson.D{
@@ -487,7 +491,7 @@ func RetractVolumeVersion(c context.Context, id string, version int, submitterID
 // SetCurrentVolumeVersion rolls a record back (or forward) to an arbitrary existing version,
 // independent of the submit/review flow - marking that version live and archiving whichever
 // version was previously current.
-func SetCurrentVolumeVersion(c context.Context, id string, version int) (*vo.VolumeVersionVO, error) {
+func SetCurrentVolumeVersion(c context.Context, id string, version int, actingUserID string) (*vo.VolumeVersionVO, error) {
 	meta, err := getVolumeMeta(c, id)
 	if err != nil {
 		return nil, err
@@ -514,7 +518,7 @@ func SetCurrentVolumeVersion(c context.Context, id string, version int) (*vo.Vol
 	if err := setVolumeVersionState(c, id, version, bson.D{{Key: "state", Value: string(models.VersionStateLive)}}); err != nil {
 		return nil, err
 	}
-	if err := setVolumeMetaCurrentVersion(c, id, version); err != nil {
+	if err := setVolumeMetaCurrentVersion(c, id, version, actingUserID); err != nil {
 		return nil, err
 	}
 

--- a/gamesystems/client.go
+++ b/gamesystems/client.go
@@ -52,6 +52,27 @@ type gameSystemResponse struct {
 	} `json:"tags"`
 	SubmittedBy string    `json:"submitted_by"`
 	SubmittedAt time.Time `json:"submitted_at"`
+	// Platform audit block from game-systems-api's stable record (EntityMeta), added when that
+	// service adopted the audit-fields convention. Absent on a pre-adoption response, in which
+	// case these decode to zero and the caller falls back to submitted_* below.
+	CreatedBy string    `json:"created_by"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedBy string    `json:"updated_by"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// audit resolves the response's audit fields, preferring the real created_*/updated_* and
+// falling back to the version's submitted_* for a pre-adoption game-systems-api.
+func (r gameSystemResponse) audit() (createdAt, updatedAt time.Time, createdBy, updatedBy string) {
+	createdAt, createdBy = r.CreatedAt, r.CreatedBy
+	if createdAt.IsZero() {
+		createdAt, createdBy = r.SubmittedAt, r.SubmittedBy
+	}
+	updatedAt, updatedBy = r.UpdatedAt, r.UpdatedBy
+	if updatedAt.IsZero() {
+		updatedAt, updatedBy = createdAt, createdBy
+	}
+	return
 }
 
 // System is the resolved shape a caller needs to fill in a volume's system reference.
@@ -63,6 +84,8 @@ type System struct {
 	Tags      []modelcore.TagVO
 	CreatedBy string
 	CreatedAt time.Time
+	UpdatedBy string
+	UpdatedAt time.Time
 }
 
 // Get resolves one game system by id against its current (live) version.
@@ -90,9 +113,11 @@ func (c *Client) Get(ctx context.Context, id string) (*System, error) {
 		return nil, fmt.Errorf("game-systems: decode get response: %w", err)
 	}
 
+	createdAt, updatedAt, createdBy, updatedBy := body.audit()
 	return &System{
 		ID: body.RecordID, Name: body.Name, Edition: body.Edition, Notes: body.Notes,
-		Tags: toTagVOs(body.Tags), CreatedBy: body.SubmittedBy, CreatedAt: body.SubmittedAt,
+		Tags:      toTagVOs(body.Tags),
+		CreatedBy: createdBy, CreatedAt: createdAt, UpdatedBy: updatedBy, UpdatedAt: updatedAt,
 	}, nil
 }
 
@@ -122,9 +147,11 @@ func (c *Client) List(ctx context.Context) ([]*System, error) {
 
 	systems := make([]*System, len(all))
 	for i, gs := range all {
+		createdAt, updatedAt, createdBy, updatedBy := gs.audit()
 		systems[i] = &System{
 			ID: gs.RecordID, Name: gs.Name, Edition: gs.Edition, Notes: gs.Notes,
-			Tags: toTagVOs(gs.Tags), CreatedBy: gs.SubmittedBy, CreatedAt: gs.SubmittedAt,
+			Tags:      toTagVOs(gs.Tags),
+			CreatedBy: createdBy, CreatedAt: createdAt, UpdatedBy: updatedBy, UpdatedAt: updatedAt,
 		}
 	}
 	return systems, nil
@@ -150,9 +177,9 @@ func (c *Client) GetStats(ctx context.Context) (*Stats, error) {
 
 	stats := &Stats{Count: len(systems)}
 	for _, s := range systems {
-		if stats.LastUpdated == nil || s.CreatedAt.After(*stats.LastUpdated) {
-			createdAt := s.CreatedAt
-			stats.LastUpdated = &createdAt
+		if stats.LastUpdated == nil || s.UpdatedAt.After(*stats.LastUpdated) {
+			updatedAt := s.UpdatedAt
+			stats.LastUpdated = &updatedAt
 			stats.MostRecentID = s.ID
 			stats.MostRecentName = s.Name
 		}

--- a/gamesystems/client_test.go
+++ b/gamesystems/client_test.go
@@ -46,3 +46,26 @@ func TestGetNotFound(t *testing.T) {
 		t.Fatalf("Get() error = %v, want NotFoundError", err)
 	}
 }
+
+func TestResponseAuditPrefersRealFieldsWithSubmittedFallback(t *testing.T) {
+	created := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	updated := time.Date(2026, 2, 2, 0, 0, 0, 0, time.UTC)
+	submitted := time.Date(2025, 12, 12, 0, 0, 0, 0, time.UTC)
+
+	// Post-adoption: real created_*/updated_* win.
+	full := gameSystemResponse{
+		CreatedAt: created, CreatedBy: "u1", UpdatedAt: updated, UpdatedBy: "u2",
+		SubmittedAt: submitted, SubmittedBy: "s1",
+	}
+	cAt, uAt, cBy, uBy := full.audit()
+	if !cAt.Equal(created) || cBy != "u1" || !uAt.Equal(updated) || uBy != "u2" {
+		t.Errorf("full response: got (%v,%v,%q,%q), want real created/updated", cAt, uAt, cBy, uBy)
+	}
+
+	// Pre-adoption: no created_*/updated_*, fall back to submitted_* for both.
+	legacy := gameSystemResponse{SubmittedAt: submitted, SubmittedBy: "s1"}
+	cAt, uAt, cBy, uBy = legacy.audit()
+	if !cAt.Equal(submitted) || cBy != "s1" || !uAt.Equal(submitted) || uBy != "s1" {
+		t.Errorf("legacy response: got (%v,%v,%q,%q), want submitted_* fallback", cAt, uAt, cBy, uBy)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,9 @@ go 1.26.5
 require (
 	github.com/stretchr/testify v1.12.1
 	github.com/sweetrpg/api-core.go v0.1.1
-	github.com/sweetrpg/catalog-objects.go v0.5.0
+	github.com/sweetrpg/catalog-objects.go v0.6.0
 	github.com/sweetrpg/common.go v0.0.16
-	github.com/sweetrpg/model-core.go v0.0.173
+	github.com/sweetrpg/model-core.go v0.1.0
 	github.com/sweetrpg/mongodb.go v0.0.193
 	go.mongodb.org/mongo-driver v1.17.9
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.70.0

--- a/go.sum
+++ b/go.sum
@@ -31,10 +31,14 @@ github.com/sweetrpg/api-core.go v0.1.1 h1:qqr5Rgiaw7n2RtDZ7fdoy5vw8RT3L42orhJ/x+
 github.com/sweetrpg/api-core.go v0.1.1/go.mod h1:ka2gLYUlukRaBXiaaohfRSHoNH77oSrTkkik07Z+lj0=
 github.com/sweetrpg/catalog-objects.go v0.5.0 h1:v5yyLUHbQ1wQ7r5CjKo/nBazKjDZVEaSjoHaj2l0EcA=
 github.com/sweetrpg/catalog-objects.go v0.5.0/go.mod h1:qwB2oluVsq8WSdnZHQTAZ5Z3ZeYrLkimVZPT/jilDs4=
+github.com/sweetrpg/catalog-objects.go v0.6.0 h1:1yWzmcfOrMWF8GC4lYsq6165FNeR4ZYY+bmGlk1xuzc=
+github.com/sweetrpg/catalog-objects.go v0.6.0/go.mod h1:qwB2oluVsq8WSdnZHQTAZ5Z3ZeYrLkimVZPT/jilDs4=
 github.com/sweetrpg/common.go v0.0.16 h1:XT8PwUXz0BOMIITXLjw3G6rEjjRUEs0Xs4+R9o2fVBk=
 github.com/sweetrpg/common.go v0.0.16/go.mod h1:PVpjDIeB/bZYJZk5fc8whuqVJE8K5k/DsO3o+aZFEcE=
 github.com/sweetrpg/model-core.go v0.0.173 h1:mIZ4z0ETkCH7I3Az0jwTFOyh66OTm7Z4/f0Rx/w+5Fk=
 github.com/sweetrpg/model-core.go v0.0.173/go.mod h1:8L1qsYxAhEe/nx5yUxvaosPtpRlUnLuXj+GI76zpQok=
+github.com/sweetrpg/model-core.go v0.1.0 h1:ac8kdyj7oLN706JYyUvMB4T0HRkq9gmzObn3YMUTqCo=
+github.com/sweetrpg/model-core.go v0.1.0/go.mod h1:aufDyXjagNyPQADwa6INTv1OI/rIOSjTXtqkzcw1fgA=
 github.com/sweetrpg/mongodb.go v0.0.193 h1:9SvQK3QYftFP1GglMrMvBBlWbIAnSnjQ2Vg13uxQLkQ=
 github.com/sweetrpg/mongodb.go v0.0.193/go.mod h1:4+3gfWtpBHrMWNHrAL4th/hbn1Pq9eT8iLp5ocjs3pI=
 github.com/xdg-go/pbkdf2 v1.0.0 h1:Su7DPu48wXMwC3bs7MCNG+z4FhcyEuz5dlvchbq0B0c=


### PR DESCRIPTION
Part of the platform audit-fields convention — `sweetrpg/platform#86`, task 9.4. `PADR-0001`.

Bumps `catalog-objects.go` v0.6.0 (meta records gain `updated_*`) and `model-core.go` v0.1.0.

## Change

- `setMetaCurrentVersion` / `setVolumeMetaCurrentVersion` gain an `actingUserID` param, stamp
  `updated_at` / `updated_by`. Threaded from `createVersion` (submittedBy), `acceptVersion`
  (reviewedBy), `setCurrentVersion` (new param).
- `softDelete` / `SoftDeleteVolume` also stamp `updated_*`. `restore` / `RestoreVolume` gain a
  `restoredBy` param and stamp it.
- `addEntity` / `AddVolume` stamp `updated_* = created_*`.
- `flattenX` / `flattenVolume` now source the whole audit block from the **meta record**, not the
  version's `submitted_*` — so a flattened read reflects the record's real last-updated stamp.
- `migrateEntity` / `MigrateVolumes` carry `updated_*` onto the meta record.
- `gamesystems` client decodes game-systems-api's real `created_*` / `updated_*` (its meta audit
  block), falling back to `submitted_*` for a pre-adoption response; `system_client` VOs pass the
  real `updated_*` through.

## Breaking (internal — `catalog-api` threads these in its own PR)

`RestoreX(id, restoredBy)`, `SetCurrentXVersion(id, version, actingUserID)`,
`RestoreVolume(id, restoredBy)`, `SetCurrentVolumeVersion(id, version, actingUserID)`.

## Tests

- `gamesystems/client_test.go`: `audit()` prefers real `created_*`/`updated_*`, falls back to
  `submitted_*`.
- `go build` / `vet` pass; `data/` container tests run in CI.

Data fix (stamp `updated_* = created_*` on existing `*_meta` docs) is done directly in Mongo -
`sweetrpg/platform#86` task 9.4 step 5.

Closes #73