### PR TITLE
fix(data): use CountDocuments for stats, add state+submitted_at index

### DIFF
--- a/data/entity_versioning.go
+++ b/data/entity_versioning.go
@@ -71,21 +71,22 @@ type TypeStats struct {
 	MostRecentName string
 }
 
-// stats computes a TypeStats over cfg's live version collection - sorted-descending-limit-1 for
-// the most recent record (design.md's decision: necessary anyway since "most recent" needs the
-// specific record, not just a max timestamp, unlike GetCatalogStats' volume-only precedent) plus
-// a separate unlimited count query, matching this package's existing "no driver-level
-// CountDocuments" convention (see GetCatalogStats).
+// stats computes a TypeStats over cfg's live version collection - a driver-level CountDocuments
+// for the count (was `len(unlimited Query(...))`, which pulled every live document over the wire
+// just to count them - fine at hobby-catalog scale, not once a bulk import inflates a collection)
+// plus sorted-descending-limit-1 for the most recent record (design.md's decision: necessary
+// anyway since "most recent" needs the specific record, not just a max timestamp, unlike
+// GetCatalogStats' volume-only precedent). Both queries share the state+submitted_at index
+// ensureIndexes creates below.
 func (cfg entityVersioningConfig[T]) stats(c context.Context) (*TypeStats, error) {
 	filter := bson.D{{Key: "state", Value: string(models.VersionStateLive)}}
 
-	countProjection := bson.D{{Key: "record_id", Value: 1}}
-	all, err := database.Query[T](cfg.versionCollection, filter, nil, countProjection, 0, 0)
+	count, err := database.Db.Collection(cfg.versionCollection).CountDocuments(c, filter)
 	if err != nil {
 		return nil, fmt.Errorf("%s: count live versions: %w", cfg.typeName, err)
 	}
 
-	stats := &TypeStats{Count: len(all)}
+	stats := &TypeStats{Count: int(count)}
 	if stats.Count == 0 {
 		return stats, nil
 	}
@@ -119,6 +120,15 @@ func (cfg entityVersioningConfig[T]) ensureIndexes(c context.Context) error {
 	})
 	if err != nil {
 		return fmt.Errorf("%s: create record_id+state index: %w", cfg.typeName, err)
+	}
+	// Backs stats()'s count (state-only equality) and most-recent (state equality + submitted_at
+	// sort) queries - neither can use the record_id-leading index above, since neither filters on
+	// record_id.
+	_, err = database.Db.Collection(cfg.versionCollection).Indexes().CreateOne(c, mongo.IndexModel{
+		Keys: bson.D{{Key: "state", Value: 1}, {Key: "submitted_at", Value: -1}},
+	})
+	if err != nil {
+		return fmt.Errorf("%s: create state+submitted_at index: %w", cfg.typeName, err)
 	}
 	return nil
 }

--- a/data/volume.go
+++ b/data/volume.go
@@ -467,11 +467,11 @@ type CatalogStats struct {
 	LastUpdated *time.Time
 }
 
-// GetCatalogStats computes CatalogStats over every live volume version. Uses an unlimited
-// database.Query (limit 0) rather than a driver-level CountDocuments/aggregate, matching this
-// package's existing pattern of going through database.Query rather than reaching past it to
-// the raw mongo-driver collection - catalog sizes here are small enough (an indie/hobby
-// catalog, not a high-volume one) that this isn't a real cost.
+// GetCatalogStats computes CatalogStats over every live volume version - a driver-level
+// CountDocuments for the count plus a sorted-descending-limit-1 query for LastUpdated (was
+// `len(unlimited Query(...))` pulling every live document over the wire just to count/max them;
+// fine at hobby-catalog scale, not once a bulk import inflates the collection). Both queries
+// share the state+submitted_at index EnsureVolumeVersioningIndexes creates.
 func GetCatalogStats(c context.Context) (*CatalogStats, error) {
 	logging.Logger.Info("GetCatalogStats", "c", c)
 
@@ -479,20 +479,27 @@ func GetCatalogStats(c context.Context) (*CatalogStats, error) {
 	defer span.End()
 
 	filter := bson.D{{Key: "state", Value: string(models.VersionStateLive)}}
-	projection := bson.D{{Key: "submitted_at", Value: 1}}
 
-	versions, err := database.Query[models.VolumeVersion](volumeVersionCollection, filter, nil, projection, 0, 0)
+	count, err := database.Db.Collection(volumeVersionCollection).CountDocuments(c, filter)
 	if err != nil {
 		logging.Logger.Error(fmt.Sprintf("Error while querying database for catalog stats: %+v", err))
 		return nil, err
 	}
 
-	stats := &CatalogStats{VolumeCount: len(versions)}
-	for _, version := range versions {
-		if stats.LastUpdated == nil || version.SubmittedAt.After(*stats.LastUpdated) {
-			submittedAt := version.SubmittedAt
-			stats.LastUpdated = &submittedAt
-		}
+	stats := &CatalogStats{VolumeCount: int(count)}
+	if stats.VolumeCount == 0 {
+		return stats, nil
+	}
+
+	sortOrder := bson.D{{Key: "submitted_at", Value: -1}}
+	projection := bson.D{{Key: "submitted_at", Value: 1}}
+	recent, err := database.Query[models.VolumeVersion](volumeVersionCollection, filter, sortOrder, projection, 0, 1)
+	if err != nil {
+		logging.Logger.Error(fmt.Sprintf("Error while querying database for catalog stats: %+v", err))
+		return nil, err
+	}
+	if len(recent) > 0 {
+		stats.LastUpdated = &recent[0].SubmittedAt
 	}
 
 	logging.Logger.Debug("returning catalog stats", "stats", stats)
@@ -509,13 +516,12 @@ func GetVolumeTypeStats(c context.Context) (*TypeStats, error) {
 
 	filter := bson.D{{Key: "state", Value: string(models.VersionStateLive)}}
 
-	countProjection := bson.D{{Key: "record_id", Value: 1}}
-	all, err := database.Query[models.VolumeVersion](volumeVersionCollection, filter, nil, countProjection, 0, 0)
+	count, err := database.Db.Collection(volumeVersionCollection).CountDocuments(c, filter)
 	if err != nil {
 		return nil, fmt.Errorf("volume: count live versions: %w", err)
 	}
 
-	stats := &TypeStats{Count: len(all)}
+	stats := &TypeStats{Count: int(count)}
 	if stats.Count == 0 {
 		return stats, nil
 	}

--- a/data/volume_test.go
+++ b/data/volume_test.go
@@ -101,6 +101,18 @@ func (suite *VolumeDataTestSuite) TestGetCatalogStats() {
 	assert.NotNil(suite.T(), stats.LastUpdated)
 }
 
+func (suite *VolumeDataTestSuite) TestGetVolumeTypeStats() {
+	stats, err := GetVolumeTypeStats(suite.T().Context())
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), stats)
+	// SetupTest seeds one volume per test run (not cleared between test methods), so an exact
+	// count isn't stable here - only that the seeded volume is reflected at all, via the
+	// CountDocuments-backed count rather than the old len(unlimited Query(...)).
+	assert.GreaterOrEqual(suite.T(), stats.Count, 1)
+	assert.NotNil(suite.T(), stats.LastUpdated)
+	assert.NotEmpty(suite.T(), stats.MostRecentID)
+}
+
 func (suite *VolumeDataTestSuite) TestQueryVolumesProjected() {
 	params := apiutil.QueryParams{
 		Start:      0,

--- a/data/volume_versioning.go
+++ b/data/volume_versioning.go
@@ -42,6 +42,16 @@ func EnsureVolumeVersioningIndexes(ctx context.Context) error {
 		return fmt.Errorf("volumes: create record_id+state index: %w", err)
 	}
 
+	// Backs GetVolumeTypeStats/GetCatalogStats' count (state-only equality) and most-recent
+	// (state equality + submitted_at sort) queries - neither can use the record_id-leading index
+	// above, since neither filters on record_id.
+	_, err = database.Db.Collection(volumeVersionCollection).Indexes().CreateOne(ctx, mongo.IndexModel{
+		Keys: bson.D{{Key: "state", Value: 1}, {Key: "submitted_at", Value: -1}},
+	})
+	if err != nil {
+		return fmt.Errorf("volumes: create state+submitted_at index: %w", err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- `GetCatalogStats`/`GetVolumeTypeStats`/`entityVersioningConfig.stats` each fetched every live
  version document over the wire just to `len()` them for a count - fine at hobby-catalog scale,
  broke down once a bulk import inflated the volumes collection (catalog-web landing page 500).
- Switches all three to a driver-level `CountDocuments`.
- Adds a `state+submitted_at` index to every version collection (volumes + the 5 shared-engine
  types) - backs both the new count query and the existing sorted-descending-limit-1 "most
  recent" query, neither of which the existing `record_id`-leading indexes could serve.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` against a real MongoDB (added `TestGetVolumeTypeStats`, extended coverage
      of `GetCatalogStats`/`GetStudioStats` already exercised the shared-engine path)