### PR TITLE
feat(data): add GetVolumeTags tag-cloud aggregation

### DIFF
--- a/data/volume_tags.go
+++ b/data/volume_tags.go
@@ -1,0 +1,52 @@
+package data
+
+import (
+	"context"
+
+	"github.com/sweetrpg/catalog-objects.go/models"
+	"github.com/sweetrpg/common.go/logging"
+	"github.com/sweetrpg/mongodb.go/database"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// GetVolumeTags returns the distinct tag names attached to live volumes, ranked by how many
+// volumes carry each tag (most-used first). It powers the catalog-web landing-page tag cloud,
+// which drops the low-frequency tail - so limit caps the result, and an empty catalog returns an
+// empty slice. A limit of 0 or negative means "use the default cloud size".
+func GetVolumeTags(c context.Context, limit int) ([]string, error) {
+	logging.Logger.Debug("GetVolumeTags", "c", c, "limit", limit)
+	if limit <= 0 {
+		limit = 20
+	}
+	if limit > 100 {
+		limit = 100
+	}
+
+	coll := database.Db.Collection(volumeVersionCollection)
+	pipeline := mongo.Pipeline{
+		bson.D{{Key: "$match", Value: bson.D{{Key: "state", Value: string(models.VersionStateLive)}}}},
+		bson.D{{Key: "$unwind", Value: "$tags"}},
+		bson.D{{Key: "$match", Value: bson.D{{Key: "tags.name", Value: bson.D{{Key: "$ne", Value: ""}}}}}},
+		bson.D{{Key: "$sortByCount", Value: "$tags.name"}},
+		bson.D{{Key: "$limit", Value: limit}},
+	}
+
+	cur, err := coll.Aggregate(c, pipeline)
+	if err != nil {
+		return nil, err
+	}
+	var ranked []struct {
+		Name string `bson:"_id"`
+	}
+	if err := cur.All(c, &ranked); err != nil {
+		return nil, err
+	}
+
+	tags := make([]string, 0, len(ranked))
+	for _, r := range ranked {
+		tags = append(tags, r.Name)
+	}
+	logging.Logger.Debug("GetVolumeTags returned", "tags", tags)
+	return tags, nil
+}

--- a/data/volume_test.go
+++ b/data/volume_test.go
@@ -2,6 +2,7 @@ package data
 
 import (
 	"os"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,6 +11,7 @@ import (
 	"github.com/sweetrpg/catalog-objects.go/models"
 	"github.com/sweetrpg/catalog-objects.go/vo"
 	"github.com/sweetrpg/common.go/logging"
+	modelcore "github.com/sweetrpg/model-core.go/vo"
 	"github.com/sweetrpg/mongodb.go/constants"
 	"github.com/sweetrpg/mongodb.go/database"
 )
@@ -89,6 +91,42 @@ func (suite *VolumeDataTestSuite) TestQueryVolumesFiltered() {
 	volumes, err := QueryVolumes(suite.T().Context(), params)
 	assert.Nil(suite.T(), err)
 	assert.NotEmpty(suite.T(), volumes)
+}
+
+func (suite *VolumeDataTestSuite) TestGetVolumeTags() {
+	// The suite DB accumulates across runs, so counts aren't stable - only orderability and
+	// membership are asserted. Use distinctive names so no other test collides.
+	_, err := AddVolume(suite.T().Context(), &vo.VolumeVO{
+		Title: "Tagged Volume One",
+		Tags:  []modelcore.TagVO{{Name: "AlphaTag"}, {Name: "RareTag"}},
+	})
+	assert.NoError(suite.T(), err)
+	_, err = AddVolume(suite.T().Context(), &vo.VolumeVO{
+		Title: "Tagged Volume Two",
+		Tags:  []modelcore.TagVO{{Name: "AlphaTag"}},
+	})
+	assert.NoError(suite.T(), err)
+
+	tags, err := GetVolumeTags(suite.T().Context(), 20)
+	assert.NoError(suite.T(), err)
+	// AlphaTag is on at least two volumes, RareTag on one - AlphaTag must rank above RareTag.
+	assert.Contains(suite.T(), tags, "AlphaTag")
+	assert.Contains(suite.T(), tags, "RareTag")
+	assert.True(suite.T(), slices.Index(tags, "AlphaTag") < slices.Index(tags, "RareTag"))
+}
+
+func (suite *VolumeDataTestSuite) TestGetVolumeTagsLimitCapsCloud() {
+	for i := 0; i < 5; i++ {
+		_, err := AddVolume(suite.T().Context(), &vo.VolumeVO{
+			Title: "Many Tags Volume",
+			Tags:  []modelcore.TagVO{{Name: "Unique"}},
+		})
+		assert.NoError(suite.T(), err)
+	}
+
+	tags, err := GetVolumeTags(suite.T().Context(), 2)
+	assert.NoError(suite.T(), err)
+	assert.Len(suite.T(), tags, 2)
 }
 
 func (suite *VolumeDataTestSuite) TestGetCatalogStats() {


### PR DESCRIPTION
Aggregates tag counts across live volumes via a match/unwind/sortByCount pipeline, capped by a limit parameter. Adds integration tests for tag ranking and limit capping.

Unblocks catalog-api `GET /volumes/tags`.