### PR TITLE
Accept game-systems-api /systems envelope response

### DIFF
--- a/gamesystems/client.go
+++ b/gamesystems/client.go
@@ -5,9 +5,11 @@
 package gamesystems
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"time"
 
@@ -140,8 +142,8 @@ func (c *Client) List(ctx context.Context) ([]*System, error) {
 		return nil, fmt.Errorf("game-systems: unexpected status %d from list", resp.StatusCode)
 	}
 
-	var all []gameSystemResponse
-	if err := json.NewDecoder(resp.Body).Decode(&all); err != nil {
+	all, err := decodeSystemList(resp.Body)
+	if err != nil {
 		return nil, fmt.Errorf("game-systems: decode list response: %w", err)
 	}
 
@@ -155,6 +157,34 @@ func (c *Client) List(ctx context.Context) ([]*System, error) {
 		}
 	}
 	return systems, nil
+}
+
+// decodeSystemList reads GET /systems, tolerating both game-systems-api's historical bare JSON
+// array and its current { "systems": [...], "total": N, ... } envelope (added in
+// game-systems-api v0.7.0). The leading non-whitespace byte disambiguates: '[' is the old
+// array, anything else is decoded as the envelope.
+func decodeSystemList(r io.Reader) ([]gameSystemResponse, error) {
+	raw, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+	trimmed := bytes.TrimLeft(raw, " \t\r\n")
+
+	if len(trimmed) > 0 && trimmed[0] == '[' {
+		var arr []gameSystemResponse
+		if err := json.Unmarshal(raw, &arr); err != nil {
+			return nil, err
+		}
+		return arr, nil
+	}
+
+	var env struct {
+		Systems []gameSystemResponse `json:"systems"`
+	}
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return nil, err
+	}
+	return env.Systems, nil
 }
 
 // Stats is the catalog-landing-page-summary card game-systems-api backs: a live-record count

--- a/gamesystems/client_test.go
+++ b/gamesystems/client_test.go
@@ -34,6 +34,50 @@ func TestGetStatsPicksMostRecent(t *testing.T) {
 	}
 }
 
+// game-systems-api v0.7.0 changed GET /systems from a bare array to a
+// { "systems": [...], "total": N, "page": p, "per_page": pp } envelope. The client must accept
+// both so a catalog-api running against either game-systems-api version keeps working.
+func TestListAcceptsEnvelopeAndBareArray(t *testing.T) {
+	older := time.Now().Add(-time.Hour)
+	newer := time.Now()
+	rows := []gameSystemResponse{
+		{RecordID: "1", Name: "D&D", SubmittedAt: older},
+		{RecordID: "2", Name: "Pathfinder", SubmittedAt: newer},
+	}
+
+	cases := map[string]func(http.ResponseWriter){
+		"bare array": func(w http.ResponseWriter) {
+			_ = json.NewEncoder(w).Encode(rows)
+		},
+		"envelope": func(w http.ResponseWriter) {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"systems": rows, "total": 2, "page": 1, "per_page": 24,
+			})
+		},
+		"envelope with leading whitespace": func(w http.ResponseWriter) {
+			body, _ := json.Marshal(map[string]any{"systems": rows, "total": 2})
+			_, _ = w.Write(append([]byte("  \n"), body...))
+		},
+	}
+
+	for name, write := range cases {
+		t.Run(name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				write(w)
+			}))
+			defer srv.Close()
+
+			systems, err := NewClient(srv.URL).List(context.Background())
+			if err != nil {
+				t.Fatalf("List() error = %v", err)
+			}
+			if len(systems) != 2 || systems[0].ID != "1" || systems[1].Name != "Pathfinder" {
+				t.Fatalf("List() = %+v, want the two seeded systems", systems)
+			}
+		})
+	}
+}
+
 func TestGetNotFound(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)


### PR DESCRIPTION
Regression fix. `game-systems-api` **v0.7.0** changed `GET /systems` from a bare JSON array to `{ "systems": [...], "total": N, "page": p, "per_page": pp }`.

`gamesystems.Client.List` decoded straight into `[]gameSystemResponse` and now errors against v0.7.0:

```
game-systems: decode list response: json: cannot unmarshal object into Go value of type []gamesystems.gameSystemResponse
```

Live impact right now on dev: `catalog-api` `GET /stats` and `GET /systems` 500, and `catalog-web`s catalog landing page 500s downstream.

## Fix

`decodeSystemList` reads the body and branches on the first non-whitespace byte: `[` keeps the historical bare-array path; anything else decodes the envelope and returns its `systems`. `Client.Get` (`/systems/:id`) is untouched - that route still returns a bare object.

## Tests

`TestListAcceptsEnvelopeAndBareArray` - table: bare array, envelope, envelope with leading whitespace; all yield the same two systems. Existing `TestGetStatsPicksMostRecent` (bare array) still passes. `go build/vet/test` green, `golangci-lint` clean.

## Next

Needs a `catalog-data.go` release, then a `catalog-api` `go.mod` bump + release (v0.32.2) - @ Foreman offered to cut those.

## Note

Commit `a454aa2` is unsigned - 1Password signing blocked in this automation env. Re-sign + force-push needed before merge if `develop` requires signatures.