### PR TITLE
Query-layer filter/sort/search for browse list functions

### DIFF
--- a/data/entity_versioning.go
+++ b/data/entity_versioning.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"time"
 
+	apiutil "github.com/sweetrpg/api-core.go/util"
 	"github.com/sweetrpg/catalog-objects.go/models"
 	modelcore "github.com/sweetrpg/model-core.go/models"
 	"github.com/sweetrpg/mongodb.go/database"
@@ -16,6 +17,45 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
+
+// searchTermField is the reserved filter key for a multi-field substring search. A
+// params.Filter entry with this Field is expanded to a case-insensitive $or across the
+// entity's search fields (see design.md's "Multi-field substring search" decision) rather than
+// passed through to ConvertQueryParams as a literal field match.
+const searchTermField = "q"
+
+// extractSearchTerm pulls a searchTermField filter out of params (returning its first value and
+// a copy of params with that entry removed), so "q" never reaches ConvertQueryParams as a
+// literal field. The returned QueryParams shares no backing array with the caller's.
+func extractSearchTerm(params apiutil.QueryParams) (string, apiutil.QueryParams) {
+	var term string
+	kept := make([]apiutil.Filter, 0, len(params.Filter))
+	for _, f := range params.Filter {
+		if f.Field == searchTermField {
+			if len(f.Value) > 0 {
+				term = f.Value[0]
+			}
+			continue
+		}
+		kept = append(kept, f)
+	}
+	params.Filter = kept
+	return term, params
+}
+
+// appendSearchOr adds a case-insensitive "contains" $or across fields for a non-empty term.
+// Each clause is the same { $regex, $options: "i" } shape api-core.go's contains operator
+// produces, so a per-field filter[x][contains]=y and a multi-field q stay consistent.
+func appendSearchOr(filter bson.D, term string, fields []string) bson.D {
+	if term == "" || len(fields) == 0 {
+		return filter
+	}
+	or := make(bson.A, 0, len(fields))
+	for _, f := range fields {
+		or = append(or, bson.D{{Key: f, Value: bson.D{{Key: "$regex", Value: term}, {Key: "$options", Value: "i"}}}})
+	}
+	return append(filter, bson.E{Key: "$or", Value: or})
+}
 
 // parseWebsite best-effort parses a VO's plain-string website into the url.URL the models layer
 // still stores (Mongo bson round-trips url.URL fine - only the JSON:API wire format needed the
@@ -56,9 +96,54 @@ type entityVersioningConfig[T any] struct {
 	// already exposes (State, SubmittedAt).
 	recordID    func(*T) string
 	displayName func(*T) string
+	// searchFields are the version-document bson fields a browse-page substring search covers,
+	// in preference order. searchFields[0] is also this entity's default list sort. A `q` filter
+	// param ORs a case-insensitive contains match across all of them; each is also indexed
+	// (ensureIndexes) so an exact or anchored filter on the same field stays cheap.
+	searchFields []string
 	// fields are the substantive fields a submission can change and a review can selectively
 	// accept - everything on T except its version-lifecycle bookkeeping.
 	fields map[string]entityFieldAccessor[T]
+}
+
+// metaVersion pairs a live version record with its non-deleted meta record - what query returns
+// for each match so the caller can flatten both into the entity's VO.
+type metaVersion[T any] struct {
+	Meta    *models.EntityMeta
+	Version *T
+}
+
+// query lists the current (live) version of every record matching params, excluding
+// soft-deleted records. Mirrors QueryVolumes: the filter, sort, and page window push down to
+// the version collection, then each row's meta is joined to drop soft-deleted records. A `q`
+// filter param becomes a case-insensitive $or across cfg.searchFields; with no explicit sort,
+// results order by searchFields[0].
+func (cfg entityVersioningConfig[T]) query(c context.Context, params apiutil.QueryParams) ([]metaVersion[T], error) {
+	term, rest := extractSearchTerm(params)
+	filter, sortOrder, projection := apiutil.ConvertQueryParams(rest)
+	filter = appendSearchOr(filter, term, cfg.searchFields)
+	filter = append(filter, bson.E{Key: "state", Value: string(models.VersionStateLive)})
+	if len(sortOrder) == 0 && len(cfg.searchFields) > 0 {
+		sortOrder = bson.D{{Key: cfg.searchFields[0], Value: 1}}
+	}
+
+	versions, err := database.Query[T](cfg.versionCollection, filter, sortOrder, projection, params.Start, params.Limit)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]metaVersion[T], 0, len(versions))
+	for _, v := range versions {
+		meta, err := cfg.getMeta(c, cfg.recordID(v))
+		if err != nil {
+			return nil, err
+		}
+		if meta == nil || meta.DeletedAt != nil {
+			continue
+		}
+		out = append(out, metaVersion[T]{Meta: meta, Version: v})
+	}
+	return out, nil
 }
 
 // TypeStats is one entity type's catalog-landing-page-summary card: a live-record count plus
@@ -129,6 +214,16 @@ func (cfg entityVersioningConfig[T]) ensureIndexes(c context.Context) error {
 	})
 	if err != nil {
 		return fmt.Errorf("%s: create state+submitted_at index: %w", cfg.typeName, err)
+	}
+	// One index per search field so an exact/anchored filter (or the default searchFields[0]
+	// sort) on it is index-backed. An unanchored contains $regex can't use these efficiently -
+	// tracked as a follow-up (design.md's "Index every field a contains filter can target").
+	for _, field := range cfg.searchFields {
+		if _, err := database.Db.Collection(cfg.versionCollection).Indexes().CreateOne(c, mongo.IndexModel{
+			Keys: bson.D{{Key: field, Value: 1}},
+		}); err != nil {
+			return fmt.Errorf("%s: create %s index: %w", cfg.typeName, field, err)
+		}
 	}
 	return nil
 }

--- a/data/license_versioning.go
+++ b/data/license_versioning.go
@@ -12,8 +12,6 @@ import (
 	modelcore "github.com/sweetrpg/model-core.go/models"
 	modelcoreutil "github.com/sweetrpg/model-core.go/util"
 	modelcorevo "github.com/sweetrpg/model-core.go/vo"
-	"github.com/sweetrpg/mongodb.go/database"
-	"go.mongodb.org/mongo-driver/bson"
 )
 
 const (
@@ -31,6 +29,7 @@ var licenseVersioning = entityVersioningConfig[models.LicenseVersion]{
 	setVersion:        func(v *models.LicenseVersion, n int) { v.Version = n },
 	recordID:          func(v *models.LicenseVersion) string { return v.RecordID },
 	displayName:       func(v *models.LicenseVersion) string { return v.Title },
+	searchFields:      []string{"title"},
 	fields: map[string]entityFieldAccessor[models.LicenseVersion]{
 		"title":         {get: func(v *models.LicenseVersion) any { return v.Title }, set: func(v *models.LicenseVersion, val any) { v.Title = val.(string) }},
 		"short_title":   {get: func(v *models.LicenseVersion) any { return v.ShortTitle }, set: func(v *models.LicenseVersion, val any) { v.ShortTitle = val.(string) }},
@@ -201,22 +200,13 @@ func CountSubmittedLicenseVersionsBySubmitter(c context.Context, submittedBy str
 
 // QueryLicenses lists the current (live) version of every license matching params.
 func QueryLicenses(c context.Context, params apiutil.QueryParams) ([]*vo.LicenseVO, error) {
-	filter, sort, projection := apiutil.ConvertQueryParams(params)
-	filter = append(filter, bson.E{Key: "deleted_at", Value: nil})
-	metas, err := database.Query[models.EntityMeta](licenseMetaCollection, filter, sort, projection, params.Start, params.Limit)
+	rows, err := licenseVersioning.query(c, params)
 	if err != nil {
 		return nil, err
 	}
-	vos := make([]*vo.LicenseVO, 0, len(metas))
-	for _, meta := range metas {
-		version, err := licenseVersioning.getVersion(c, meta.ID, meta.CurrentVersion)
-		if err != nil {
-			return nil, err
-		}
-		if version == nil {
-			continue
-		}
-		vos = append(vos, flattenLicense(meta, version))
+	vos := make([]*vo.LicenseVO, 0, len(rows))
+	for _, r := range rows {
+		vos = append(vos, flattenLicense(r.Meta, r.Version))
 	}
 	return vos, nil
 }

--- a/data/person_versioning.go
+++ b/data/person_versioning.go
@@ -11,8 +11,6 @@ import (
 	modelcore "github.com/sweetrpg/model-core.go/models"
 	modelcoreutil "github.com/sweetrpg/model-core.go/util"
 	modelcorevo "github.com/sweetrpg/model-core.go/vo"
-	"github.com/sweetrpg/mongodb.go/database"
-	"go.mongodb.org/mongo-driver/bson"
 )
 
 const (
@@ -30,6 +28,7 @@ var personVersioning = entityVersioningConfig[models.PersonVersion]{
 	setVersion:        func(v *models.PersonVersion, n int) { v.Version = n },
 	recordID:          func(v *models.PersonVersion) string { return v.RecordID },
 	displayName:       func(v *models.PersonVersion) string { return v.Name },
+	searchFields:      []string{"name"},
 	fields: map[string]entityFieldAccessor[models.PersonVersion]{
 		"name":       {get: func(v *models.PersonVersion) any { return v.Name }, set: func(v *models.PersonVersion, val any) { v.Name = val.(string) }},
 		"notes":      {get: func(v *models.PersonVersion) any { return v.Notes }, set: func(v *models.PersonVersion, val any) { v.Notes = val.(string) }},
@@ -187,22 +186,13 @@ func CountSubmittedPersonVersionsBySubmitter(c context.Context, submittedBy stri
 
 // QueryPersons lists the current (live) version of every person matching params.
 func QueryPersons(c context.Context, params apiutil.QueryParams) ([]*vo.PersonVO, error) {
-	filter, sort, projection := apiutil.ConvertQueryParams(params)
-	filter = append(filter, bson.E{Key: "deleted_at", Value: nil})
-	metas, err := database.Query[models.EntityMeta](personMetaCollection, filter, sort, projection, params.Start, params.Limit)
+	rows, err := personVersioning.query(c, params)
 	if err != nil {
 		return nil, err
 	}
-	vos := make([]*vo.PersonVO, 0, len(metas))
-	for _, meta := range metas {
-		version, err := personVersioning.getVersion(c, meta.ID, meta.CurrentVersion)
-		if err != nil {
-			return nil, err
-		}
-		if version == nil {
-			continue
-		}
-		vos = append(vos, flattenPerson(meta, version))
+	vos := make([]*vo.PersonVO, 0, len(rows))
+	for _, r := range rows {
+		vos = append(vos, flattenPerson(r.Meta, r.Version))
 	}
 	return vos, nil
 }

--- a/data/publisher_versioning.go
+++ b/data/publisher_versioning.go
@@ -12,8 +12,6 @@ import (
 	modelcore "github.com/sweetrpg/model-core.go/models"
 	modelcoreutil "github.com/sweetrpg/model-core.go/util"
 	modelcorevo "github.com/sweetrpg/model-core.go/vo"
-	"github.com/sweetrpg/mongodb.go/database"
-	"go.mongodb.org/mongo-driver/bson"
 )
 
 const (
@@ -31,6 +29,7 @@ var publisherVersioning = entityVersioningConfig[models.PublisherVersion]{
 	setVersion:        func(v *models.PublisherVersion, n int) { v.Version = n },
 	recordID:          func(v *models.PublisherVersion) string { return v.RecordID },
 	displayName:       func(v *models.PublisherVersion) string { return v.Name },
+	searchFields:      []string{"name"},
 	fields: map[string]entityFieldAccessor[models.PublisherVersion]{
 		"name":       {get: func(v *models.PublisherVersion) any { return v.Name }, set: func(v *models.PublisherVersion, val any) { v.Name = val.(string) }},
 		"address":    {get: func(v *models.PublisherVersion) any { return v.Address }, set: func(v *models.PublisherVersion, val any) { v.Address = val.(string) }},
@@ -192,24 +191,16 @@ func CountSubmittedPublisherVersionsBySubmitter(c context.Context, submittedBy s
 	return publisherVersioning.countSubmittedBySubmitter(c, submittedBy)
 }
 
-// QueryPublishers lists the current (live) version of every publisher matching params.
+// QueryPublishers lists the current (live) version of every publisher matching params, with
+// filter/sort/page (and a `q` name search) pushed down to the query layer.
 func QueryPublishers(c context.Context, params apiutil.QueryParams) ([]*vo.PublisherVO, error) {
-	filter, sort, projection := apiutil.ConvertQueryParams(params)
-	filter = append(filter, bson.E{Key: "deleted_at", Value: nil})
-	metas, err := database.Query[models.EntityMeta](publisherMetaCollection, filter, sort, projection, params.Start, params.Limit)
+	rows, err := publisherVersioning.query(c, params)
 	if err != nil {
 		return nil, err
 	}
-	vos := make([]*vo.PublisherVO, 0, len(metas))
-	for _, meta := range metas {
-		version, err := publisherVersioning.getVersion(c, meta.ID, meta.CurrentVersion)
-		if err != nil {
-			return nil, err
-		}
-		if version == nil {
-			continue
-		}
-		vos = append(vos, flattenPublisher(meta, version))
+	vos := make([]*vo.PublisherVO, 0, len(rows))
+	for _, r := range rows {
+		vos = append(vos, flattenPublisher(r.Meta, r.Version))
 	}
 	return vos, nil
 }

--- a/data/query_pushdown_test.go
+++ b/data/query_pushdown_test.go
@@ -1,0 +1,154 @@
+package data
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	apiutil "github.com/sweetrpg/api-core.go/util"
+	"github.com/sweetrpg/catalog-objects.go/vo"
+	"github.com/sweetrpg/common.go/logging"
+	dbconstants "github.com/sweetrpg/mongodb.go/constants"
+	"github.com/sweetrpg/mongodb.go/database"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+// QueryPushdownTestSuite covers stage 2 of catalog-list-handlers-query-pushdown: the multi-field
+// `q` search on QueryVolumes, the shared name-`contains` filter on the four engine entities, and
+// the search-field indexes that back them.
+type QueryPushdownTestSuite struct {
+	suite.Suite
+}
+
+func (suite *QueryPushdownTestSuite) SetupTest() {
+	_ = os.Setenv(dbconstants.DB_URI, os.Getenv("TEST_DB_URI"))
+	logging.Init()
+	database.SetupDatabase()
+	ctx := suite.T().Context()
+	for _, ensure := range []func(context.Context) error{
+		EnsureVolumeVersioningIndexes, EnsurePublisherVersioningIndexes,
+		EnsureStudioVersioningIndexes, EnsurePersonVersioningIndexes,
+		EnsureLicenseVersioningIndexes,
+	} {
+		assert.NoError(suite.T(), ensure(ctx))
+	}
+}
+
+func regexFilter(field, value string) []apiutil.Filter {
+	op := "$regex"
+	return []apiutil.Filter{{Field: field, Operation: &op, Value: []string{value}}}
+}
+
+func (suite *QueryPushdownTestSuite) indexExists(collection, name string) bool {
+	cur, err := database.Db.Collection(collection).Indexes().List(suite.T().Context())
+	assert.NoError(suite.T(), err)
+	var specs []bson.M
+	assert.NoError(suite.T(), cur.All(suite.T().Context(), &specs))
+	for _, s := range specs {
+		if s["name"] == name {
+			return true
+		}
+	}
+	return false
+}
+
+// 2.2: a `q` matching only a volume's description (not its title) is returned.
+func (suite *QueryPushdownTestSuite) TestQueryVolumesMultiFieldSearchMatchesDescriptionOnly() {
+	ctx := suite.T().Context()
+	hit, err := AddVolume(ctx, &vo.VolumeVO{Title: "Wholly Ordinary Title", Description: "mentions qpzz2marker in the blurb"})
+	assert.NoError(suite.T(), err)
+	_, err = AddVolume(ctx, &vo.VolumeVO{Title: "qpzz2marker Not In Description", Description: "clean"})
+	assert.NoError(suite.T(), err)
+
+	results, err := QueryVolumes(ctx, apiutil.QueryParams{
+		Limit:  200,
+		Filter: []apiutil.Filter{{Field: "q", Value: []string{"qpzz2marker"}}},
+	})
+	assert.NoError(suite.T(), err)
+
+	var ids []string
+	for _, r := range results {
+		ids = append(ids, r.ID)
+	}
+	assert.Contains(suite.T(), ids, *hit, "volume whose description contains the term must match")
+	// The title-only match is also returned (q ORs across title too) - the point of 2.2 is that
+	// a description-only hit is not missed, which the Contains above proves.
+}
+
+// 2.3: name-`contains` filter returns only matching records - one per engine entity type.
+func (suite *QueryPushdownTestSuite) TestQueryPublishersNameContains() {
+	ctx := suite.T().Context()
+	hit, err := AddPublisher(ctx, &vo.PublisherVO{Name: "Qpzz3 Marker Press"})
+	assert.NoError(suite.T(), err)
+	_, err = AddPublisher(ctx, &vo.PublisherVO{Name: "Different House"})
+	assert.NoError(suite.T(), err)
+
+	results, err := QueryPublishers(ctx, apiutil.QueryParams{Limit: 200, Filter: regexFilter("name", "qpzz3")})
+	assert.NoError(suite.T(), err)
+	assert.Len(suite.T(), results, 1)
+	if len(results) == 1 {
+		assert.Equal(suite.T(), *hit, results[0].ID)
+	}
+}
+
+func (suite *QueryPushdownTestSuite) TestQueryStudiosNameContains() {
+	ctx := suite.T().Context()
+	hit, err := AddStudio(ctx, &vo.StudioVO{Name: "Qpzz4 Marker Studio"})
+	assert.NoError(suite.T(), err)
+	_, err = AddStudio(ctx, &vo.StudioVO{Name: "Unrelated Studio"})
+	assert.NoError(suite.T(), err)
+
+	results, err := QueryStudios(ctx, apiutil.QueryParams{Limit: 200, Filter: regexFilter("name", "qpzz4")})
+	assert.NoError(suite.T(), err)
+	assert.Len(suite.T(), results, 1)
+	if len(results) == 1 {
+		assert.Equal(suite.T(), *hit, results[0].ID)
+	}
+}
+
+func (suite *QueryPushdownTestSuite) TestQueryPersonsNameContains() {
+	ctx := suite.T().Context()
+	hit, err := AddPerson(ctx, &vo.PersonVO{Name: "Qpzz5 Marker Person"})
+	assert.NoError(suite.T(), err)
+	_, err = AddPerson(ctx, &vo.PersonVO{Name: "Someone Else"})
+	assert.NoError(suite.T(), err)
+
+	results, err := QueryPersons(ctx, apiutil.QueryParams{Limit: 200, Filter: regexFilter("name", "qpzz5")})
+	assert.NoError(suite.T(), err)
+	assert.Len(suite.T(), results, 1)
+	if len(results) == 1 {
+		assert.Equal(suite.T(), *hit, results[0].ID)
+	}
+}
+
+func (suite *QueryPushdownTestSuite) TestQueryLicensesTitleContains() {
+	ctx := suite.T().Context()
+	hit, err := AddLicense(ctx, &vo.LicenseVO{Title: "Qpzz6 Marker License"})
+	assert.NoError(suite.T(), err)
+	_, err = AddLicense(ctx, &vo.LicenseVO{Title: "Ordinary License"})
+	assert.NoError(suite.T(), err)
+
+	results, err := QueryLicenses(ctx, apiutil.QueryParams{Limit: 200, Filter: regexFilter("title", "qpzz6")})
+	assert.NoError(suite.T(), err)
+	assert.Len(suite.T(), results, 1)
+	if len(results) == 1 {
+		assert.Equal(suite.T(), *hit, results[0].ID)
+	}
+}
+
+// 2.4: each search field has a backing index.
+func (suite *QueryPushdownTestSuite) TestSearchIndexesExist() {
+	for _, field := range []string{"title_1", "description_1", "tags.value_1"} {
+		assert.True(suite.T(), suite.indexExists(volumeVersionCollection, field), "volumes: %s", field)
+	}
+	assert.True(suite.T(), suite.indexExists(publisherVersionCollection, "name_1"))
+	assert.True(suite.T(), suite.indexExists(studioVersionCollection, "name_1"))
+	assert.True(suite.T(), suite.indexExists(personVersionCollection, "name_1"))
+	assert.True(suite.T(), suite.indexExists(licenseVersionCollection, "title_1"))
+}
+
+func TestQueryPushdownTestSuite(t *testing.T) {
+	suite.Run(t, new(QueryPushdownTestSuite))
+}

--- a/data/studio_versioning.go
+++ b/data/studio_versioning.go
@@ -12,8 +12,6 @@ import (
 	modelcore "github.com/sweetrpg/model-core.go/models"
 	modelcoreutil "github.com/sweetrpg/model-core.go/util"
 	modelcorevo "github.com/sweetrpg/model-core.go/vo"
-	"github.com/sweetrpg/mongodb.go/database"
-	"go.mongodb.org/mongo-driver/bson"
 )
 
 const (
@@ -31,6 +29,7 @@ var studioVersioning = entityVersioningConfig[models.StudioVersion]{
 	setVersion:        func(v *models.StudioVersion, n int) { v.Version = n },
 	recordID:          func(v *models.StudioVersion) string { return v.RecordID },
 	displayName:       func(v *models.StudioVersion) string { return v.Name },
+	searchFields:      []string{"name"},
 	fields: map[string]entityFieldAccessor[models.StudioVersion]{
 		"name":       {get: func(v *models.StudioVersion) any { return v.Name }, set: func(v *models.StudioVersion, val any) { v.Name = val.(string) }},
 		"website":    {get: func(v *models.StudioVersion) any { return v.Website }, set: func(v *models.StudioVersion, val any) { v.Website = val.(url.URL) }},
@@ -189,22 +188,13 @@ func CountSubmittedStudioVersionsBySubmitter(c context.Context, submittedBy stri
 
 // QueryStudios lists the current (live) version of every studio matching params.
 func QueryStudios(c context.Context, params apiutil.QueryParams) ([]*vo.StudioVO, error) {
-	filter, sort, projection := apiutil.ConvertQueryParams(params)
-	filter = append(filter, bson.E{Key: "deleted_at", Value: nil})
-	metas, err := database.Query[models.EntityMeta](studioMetaCollection, filter, sort, projection, params.Start, params.Limit)
+	rows, err := studioVersioning.query(c, params)
 	if err != nil {
 		return nil, err
 	}
-	vos := make([]*vo.StudioVO, 0, len(metas))
-	for _, meta := range metas {
-		version, err := studioVersioning.getVersion(c, meta.ID, meta.CurrentVersion)
-		if err != nil {
-			return nil, err
-		}
-		if version == nil {
-			continue
-		}
-		vos = append(vos, flattenStudio(meta, version))
+	vos := make([]*vo.StudioVO, 0, len(rows))
+	for _, r := range rows {
+		vos = append(vos, flattenStudio(r.Meta, r.Version))
 	}
 	return vos, nil
 }

--- a/data/volume.go
+++ b/data/volume.go
@@ -391,7 +391,12 @@ func QueryVolumes(c context.Context, params apiutil.QueryParams) ([]*vo.VolumeVO
 	span := tracing.BuildSpanWithParams(c, "volumes", "db-get-volumes", params)
 	defer span.End()
 
+	// A `q` filter param is a browse-page multi-field search: a case-insensitive contains match
+	// ORed across a volume's title, description, and tag values (design.md's "Multi-field
+	// substring search" decision), rather than a literal `q` field match.
+	term, params := extractSearchTerm(params)
 	filter, sort, projection := apiutil.ConvertQueryParams(params)
+	filter = appendSearchOr(filter, term, []string{"title", "description", "tags.value"})
 	filter = append(filter, bson.E{Key: "state", Value: string(models.VersionStateLive)})
 	if len(sort) == 0 {
 		// Without an explicit sort, Mongo returns natural (insertion) order - stable for an

--- a/data/volume_versioning.go
+++ b/data/volume_versioning.go
@@ -52,6 +52,17 @@ func EnsureVolumeVersioningIndexes(ctx context.Context) error {
 		return fmt.Errorf("volumes: create state+submitted_at index: %w", err)
 	}
 
+	// One index per field QueryVolumes' `q` search ORs over. An unanchored contains $regex
+	// can't use these efficiently - see design.md's "Index every field a contains filter can
+	// target" (indexed anyway so an exact/anchored filter on the same field stays cheap).
+	for _, field := range []string{"title", "description", "tags.value"} {
+		if _, err := database.Db.Collection(volumeVersionCollection).Indexes().CreateOne(ctx, mongo.IndexModel{
+			Keys: bson.D{{Key: field, Value: 1}},
+		}); err != nil {
+			return fmt.Errorf("volumes: create %s index: %w", field, err)
+		}
+	}
+
 	return nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.5
 
 require (
 	github.com/stretchr/testify v1.12.1
-	github.com/sweetrpg/api-core.go v0.1.1
+	github.com/sweetrpg/api-core.go v0.2.0
 	github.com/sweetrpg/catalog-objects.go v0.6.0
 	github.com/sweetrpg/common.go v0.0.16
 	github.com/sweetrpg/model-core.go v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/montanaflynn/stats v0.7.1 h1:etflOAAHORrCC44V+aR6Ftzort912ZU+YLiSTuV8
 github.com/montanaflynn/stats v0.7.1/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
 github.com/stretchr/testify v1.12.1 h1:EuwCh5fleGS7H32xRwO3wRGT7DxrDhLAT6FF8MpWDWE=
 github.com/stretchr/testify v1.12.1/go.mod h1:MDEgiDPPsNp5cuIrHPPCyornHKgEVbtFUmoNlxoYthg=
-github.com/sweetrpg/api-core.go v0.1.1 h1:qqr5Rgiaw7n2RtDZ7fdoy5vw8RT3L42orhJ/x+EYX9w=
-github.com/sweetrpg/api-core.go v0.1.1/go.mod h1:ka2gLYUlukRaBXiaaohfRSHoNH77oSrTkkik07Z+lj0=
+github.com/sweetrpg/api-core.go v0.2.0 h1:iCXJuIxtdQOV8p6JbYOitntbOMmQEpJy7Gh6HkQdF6M=
+github.com/sweetrpg/api-core.go v0.2.0/go.mod h1:L27iRQqlnbAbqymjqGeSIcEJHnBKkL8w5nhq0TVa4Ow=
 github.com/sweetrpg/catalog-objects.go v0.6.0 h1:1yWzmcfOrMWF8GC4lYsq6165FNeR4ZYY+bmGlk1xuzc=
 github.com/sweetrpg/catalog-objects.go v0.6.0/go.mod h1:qwB2oluVsq8WSdnZHQTAZ5Z3ZeYrLkimVZPT/jilDs4=
 github.com/sweetrpg/common.go v0.0.16 h1:XT8PwUXz0BOMIITXLjw3G6rEjjRUEs0Xs4+R9o2fVBk=


### PR DESCRIPTION
Stage 2 of OpenSpec change `catalog-list-handlers-query-pushdown` (sweetrpg/platform#98). Tasks 2.1-2.4 + the "full suite green" of 2.5. **No release** in this PR (the Release clause of 2.5 is left for @ Handyman 2).

## 2.1 - absorb api-core.go v0.2.0

`go.mod`: `api-core.go` `v0.1.1` -> `v0.2.0` (stage 1), `go mod tidy`, `go build ./...` clean.

Note: there are **no `GetQueryParams` call sites in this repo** - the `(QueryParams, error)` breaking change is absorbed by `catalog-api` in stage 3. `catalog-data.go` only calls `ConvertQueryParams`, whose signature is unchanged.

## 2.2 - `QueryVolumes` multi-field `q`

A `params.Filter` entry with `Field == "q"` is a browse-page search: pulled out before `ConvertQueryParams`, expanded to a case-insensitive `$or` contains match across `title`, `description`, and `tags.value` (design.md decision 2). Not a new querystring syntax, not a literal `q` field.

## 2.3 - generic `query` on `entityVersioningConfig[T]`

New `cfg.query(c, params)` mirrors `QueryVolumes`: filter/sort/page push down to the **version** collection, each row`s meta joined to drop soft-deleted records, `q` -> `$or` over `cfg.searchFields`, default sort `searchFields[0]`. `QueryPublishers`/`QueryStudios`/`QueryPersons`/`QueryLicenses` now delegate to it.

This also fixes a latent bug: they used to filter the **meta** collection, which carries no `name`/`title`, so a `filter[name][contains]=` matched nothing. `searchFields`: `["name"]` for publishers/studios/persons, `["title"]` for licenses.

## 2.4 - indexes

One single-field index per search field: `title`/`description`/`tags.value` on `volumes_versions` (in `EnsureVolumeVersioningIndexes`), `name`/`title` on the engine entities (in `cfg.ensureIndexes`, iterating `searchFields`). Unanchored `$regex` can`t use these efficiently - indexed anyway per design.md so an exact/anchored filter on the same field stays cheap.

## 2.5 (partial)

`go build ./... && go vet ./... && go test ./...` green against a real MongoDB; `golangci-lint` clean. New `query_pushdown_test.go`:
- `q` matching only a volume`s description (not title) returns it
- name/title `contains` filter returns only the matching record, one test per engine entity
- every search-field index exists (`getIndexes()`)

## Note

Commit `4d09830` is **unsigned** - 1Password signing blocked in this automation env. `develop` has `required_signatures`; needs a re-sign + force-push before merge.