### PR TITLE
Remove unused SearchVolumes / volumeSearchScanLimit

### DIFF
--- a/data/volume.go
+++ b/data/volume.go
@@ -3,7 +3,6 @@ package data
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/sweetrpg/api-core.go/tracing"
@@ -436,32 +435,6 @@ func QueryVolumes(c context.Context, params apiutil.QueryParams) ([]*vo.VolumeVO
 
 	logging.Logger.Debug("returning volume value objects", "vos", vos)
 	return vos, nil
-}
-
-// volumeSearchScanLimit is far smaller than the shared searchScanLimit (5000, used by
-// SearchPublishers/SearchPersons/etc.) - QueryVolumes resolves each volume's full relation set
-// (systems, publishers, studios, licenses), so scanning 5000 volumes measured at 6-7s against a
-// warm dev catalog, blowing past game-room-web's 5s request timeout. 500 keeps this well under
-// that budget; raise only alongside a real fix (pushing the title match down to a Mongo query
-// instead of an in-memory scan over fully-hydrated volumes).
-const volumeSearchScanLimit = 500
-
-// SearchVolumes finds live volumes whose title contains query (case-insensitive), scanning up to
-// volumeSearchScanLimit volumes - see the comment there for why this doesn't use the shared
-// searchScanLimit other entities' Search* functions use.
-func SearchVolumes(c context.Context, query string) ([]*vo.VolumeVO, error) {
-	all, err := QueryVolumes(c, apiutil.QueryParams{Limit: volumeSearchScanLimit})
-	if err != nil {
-		return nil, err
-	}
-	needle := strings.ToLower(query)
-	matches := make([]*vo.VolumeVO, 0, len(all))
-	for _, v := range all {
-		if strings.Contains(strings.ToLower(v.Title), needle) {
-			matches = append(matches, v)
-		}
-	}
-	return matches, nil
 }
 
 // CatalogStats is a small aggregate over the live volume set - the total count and the most


### PR DESCRIPTION
Task 3.4 of OpenSpec change `catalog-list-handlers-query-pushdown` (sweetrpg/platform#98). Follow-up to catalog-api stage 3 (catalog-api#294), which removed `GET /volumes/search`.

## Why

`SearchVolumes` was the only caller of `volumeSearchScanLimit`, and `GET /volumes/search` (now removed in catalog-api#294) was the only caller of `SearchVolumes`. Confirmed no other consumer:
- `catalog-web`s browse page fetches `GET /volumes` and filters client-side
- `catalog-cli` marks volumes `Searchable: false`
- no other service/frontend references `/volumes/search` or `SearchVolumes`

## Change

Delete `SearchVolumes` and the `volumeSearchScanLimit` const from `data/volume.go`. Nothing else. The other entities` `Search*` functions stay - they still back `/publishers/search` etc.

`go build ./... && go vet ./... && go test ./...` green against MongoDB; `golangci-lint` clean.

Does not block catalog-api#294 - that PR notes this removal as a separate follow-up.

## Note

Commit `179a5ee` is unsigned - 1Password signing blocked in this automation env. `develop` has `required_signatures`; needs a re-sign + force-push before merge.