### PR TITLE
Query-layer Count<Entity> for list-response totals

### DIFF
--- a/data/entity_versioning.go
+++ b/data/entity_versioning.go
@@ -146,6 +146,21 @@ func (cfg entityVersioningConfig[T]) query(c context.Context, params apiutil.Que
 	return out, nil
 }
 
+// count returns how many live version records match params' filter - the same `q` $or
+// expansion over cfg.searchFields and any `filter[...][contains]` clauses query() applies, plus
+// `state: live` - via a driver CountDocuments. No documents, no sort, no page window. Backs
+// catalog-api's list-response `meta.total`. Like stats() it counts on the version collection
+// without joining meta, so a record whose meta is soft-deleted but whose live version still
+// exists is counted (query()'s per-row meta check would drop it); acceptable for a browse-pager
+// total, matching stats()'s existing behavior.
+func (cfg entityVersioningConfig[T]) count(c context.Context, params apiutil.QueryParams) (int64, error) {
+	term, rest := extractSearchTerm(params)
+	filter, _, _ := apiutil.ConvertQueryParams(rest)
+	filter = appendSearchOr(filter, term, cfg.searchFields)
+	filter = append(filter, bson.E{Key: "state", Value: string(models.VersionStateLive)})
+	return database.Db.Collection(cfg.versionCollection).CountDocuments(c, filter)
+}
+
 // TypeStats is one entity type's catalog-landing-page-summary card: a live-record count plus
 // the single most recently submitted live record, or zero-value/nil fields if the type has no
 // live records yet (see spec's "degrades gracefully for an empty entity type" requirement).

--- a/data/entity_versioning.go
+++ b/data/entity_versioning.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"reflect"
 	"sort"
+	"strings"
 	"time"
 
 	apiutil "github.com/sweetrpg/api-core.go/util"
@@ -41,6 +42,25 @@ func extractSearchTerm(params apiutil.QueryParams) (string, apiutil.QueryParams)
 	}
 	params.Filter = kept
 	return term, params
+}
+
+// normalizeSort rewrites a ConvertQueryParams sort doc so the `sort=-field` descending form
+// works. go.jtlabs.io/query keeps the leading "-" in the field name ("-name"), and
+// api-core.go's GetQueryParams hardcodes every sort Order to 1 (ascending) - so "-name" arrives
+// here as {"-name": 1}. Turn a "-" prefix into a real descending sort: {"name": -1}.
+func normalizeSort(sortOrder bson.D) bson.D {
+	if len(sortOrder) == 0 {
+		return sortOrder
+	}
+	out := make(bson.D, len(sortOrder))
+	for i, e := range sortOrder {
+		if field, found := strings.CutPrefix(e.Key, "-"); found {
+			out[i] = bson.E{Key: field, Value: -1}
+		} else {
+			out[i] = e
+		}
+	}
+	return out
 }
 
 // appendSearchOr adds a case-insensitive "contains" $or across fields for a non-empty term.
@@ -123,6 +143,7 @@ func (cfg entityVersioningConfig[T]) query(c context.Context, params apiutil.Que
 	filter, sortOrder, projection := apiutil.ConvertQueryParams(rest)
 	filter = appendSearchOr(filter, term, cfg.searchFields)
 	filter = append(filter, bson.E{Key: "state", Value: string(models.VersionStateLive)})
+	sortOrder = normalizeSort(sortOrder)
 	if len(sortOrder) == 0 && len(cfg.searchFields) > 0 {
 		sortOrder = bson.D{{Key: cfg.searchFields[0], Value: 1}}
 	}

--- a/data/license_versioning.go
+++ b/data/license_versioning.go
@@ -211,6 +211,12 @@ func QueryLicenses(c context.Context, params apiutil.QueryParams) ([]*vo.License
 	return vos, nil
 }
 
+// CountLicenses returns how many live licenses match params' filter, without fetching them -
+// backs catalog-api's list-response meta.total. Same filter as QueryLicenses.
+func CountLicenses(c context.Context, params apiutil.QueryParams) (int64, error) {
+	return licenseVersioning.count(c, params)
+}
+
 // SearchLicenses finds live licenses whose title contains query (case-insensitive), scanning the
 // full collection - see data.SearchPersons for why this scans in memory rather than pushing the
 // match down to Mongo.

--- a/data/person_versioning.go
+++ b/data/person_versioning.go
@@ -197,6 +197,12 @@ func QueryPersons(c context.Context, params apiutil.QueryParams) ([]*vo.PersonVO
 	return vos, nil
 }
 
+// CountPersons returns how many live persons match params' filter, without fetching them -
+// backs catalog-api's list-response meta.total. Same filter as QueryPersons.
+func CountPersons(c context.Context, params apiutil.QueryParams) (int64, error) {
+	return personVersioning.count(c, params)
+}
+
 // searchScanLimit bounds how many live persons SearchPersons scans in memory - name isn't a
 // field on personMetaCollection (it only lives on the version document QueryPersons resolves
 // per-meta), so there's no index-backed way to push a substring match down to Mongo without a

--- a/data/publisher_versioning.go
+++ b/data/publisher_versioning.go
@@ -205,6 +205,12 @@ func QueryPublishers(c context.Context, params apiutil.QueryParams) ([]*vo.Publi
 	return vos, nil
 }
 
+// CountPublishers returns how many live publishers match params' filter, without fetching them -
+// backs catalog-api's list-response meta.total. Same filter as QueryPublishers.
+func CountPublishers(c context.Context, params apiutil.QueryParams) (int64, error) {
+	return publisherVersioning.count(c, params)
+}
+
 // SearchPublishers finds live publishers whose name contains query (case-insensitive), scanning
 // the full collection - see data.SearchPersons for why this scans in memory rather than pushing
 // the match down to Mongo.

--- a/data/query_pushdown_test.go
+++ b/data/query_pushdown_test.go
@@ -2,8 +2,10 @@ package data
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -228,6 +230,60 @@ func (suite *QueryPushdownTestSuite) TestCountMatchesUnpaginatedQueryLength() {
 	assert.NoError(suite.T(), err)
 	cLicF, err := CountLicenses(ctx, apiutil.QueryParams{Limit: big, Filter: regexFilter("title", "cntmk5")})
 	assertCount("licenses title~cntmk5", cLicF, err, len(fLic))
+}
+
+// 3b addendum: `sort=-field` sorts descending. go.jtlabs.io/query keeps the "-" and
+// api-core.go hardcodes order 1, so normalizeSort has to turn {"-name": 1} into {"name": -1}.
+func (suite *QueryPushdownTestSuite) TestDescendingSortByPrefixedField() {
+	ctx := suite.T().Context()
+	mk := fmt.Sprintf("srt%d", time.Now().UnixNano())
+
+	for _, n := range []string{mk + " Charlie", mk + " Alpha", mk + " Bravo"} {
+		_, err := AddPublisher(ctx, &vo.PublisherVO{Name: n})
+		assert.NoError(suite.T(), err)
+	}
+	descParams := apiutil.QueryParams{
+		Limit:  100,
+		Sort:   []apiutil.Sort{{Field: "-name", Order: 1}}, // exactly what GetQueryParams yields for sort=-name
+		Filter: regexFilter("name", mk),
+	}
+	rows, err := QueryPublishers(ctx, descParams)
+	assert.NoError(suite.T(), err)
+	got := make([]string, len(rows))
+	for i, r := range rows {
+		got[i] = r.Name
+	}
+	assert.Equal(suite.T(), []string{mk + " Charlie", mk + " Bravo", mk + " Alpha"}, got)
+
+	// Ascending (plain sort=name) still works.
+	ascParams := descParams
+	ascParams.Sort = []apiutil.Sort{{Field: "name", Order: 1}}
+	rows, err = QueryPublishers(ctx, ascParams)
+	assert.NoError(suite.T(), err)
+	for i, r := range rows {
+		got[i] = r.Name
+	}
+	assert.Equal(suite.T(), []string{mk + " Alpha", mk + " Bravo", mk + " Charlie"}, got)
+}
+
+func (suite *QueryPushdownTestSuite) TestDescendingSortVolumesByPrefixedTitle() {
+	ctx := suite.T().Context()
+	mk := fmt.Sprintf("vsrt%d", time.Now().UnixNano())
+	for _, t := range []string{mk + " C", mk + " A", mk + " B"} {
+		_, err := AddVolume(ctx, &vo.VolumeVO{Title: t, Description: "x"})
+		assert.NoError(suite.T(), err)
+	}
+	rows, err := QueryVolumes(ctx, apiutil.QueryParams{
+		Limit:  100,
+		Sort:   []apiutil.Sort{{Field: "-title", Order: 1}},
+		Filter: []apiutil.Filter{{Field: "q", Value: []string{mk}}},
+	})
+	assert.NoError(suite.T(), err)
+	got := make([]string, len(rows))
+	for i, r := range rows {
+		got[i] = r.Title
+	}
+	assert.Equal(suite.T(), []string{mk + " C", mk + " B", mk + " A"}, got)
 }
 
 func TestQueryPushdownTestSuite(t *testing.T) {

--- a/data/query_pushdown_test.go
+++ b/data/query_pushdown_test.go
@@ -149,6 +149,87 @@ func (suite *QueryPushdownTestSuite) TestSearchIndexesExist() {
 	assert.True(suite.T(), suite.indexExists(licenseVersionCollection, "title_1"))
 }
 
+// 3b.1: Count<Entity> equals the length of an unpaginated Query<Entity> for the same filter,
+// both unfiltered and filtered.
+func (suite *QueryPushdownTestSuite) TestCountMatchesUnpaginatedQueryLength() {
+	ctx := suite.T().Context()
+	const big = 100000
+
+	assertCount := func(name string, count int64, err error, queryLen int) {
+		assert.NoError(suite.T(), err, name)
+		assert.EqualValues(suite.T(), queryLen, count, "%s: count must equal unpaginated Query length", name)
+	}
+
+	// Volumes: two carry the marker in the description, one does not.
+	_, err := AddVolume(ctx, &vo.VolumeVO{Title: "V A", Description: "has cntmk1 marker"})
+	assert.NoError(suite.T(), err)
+	_, err = AddVolume(ctx, &vo.VolumeVO{Title: "cntmk1 in title too", Description: "x"})
+	assert.NoError(suite.T(), err)
+	_, err = AddVolume(ctx, &vo.VolumeVO{Title: "V C", Description: "unrelated"})
+	assert.NoError(suite.T(), err)
+
+	allVols, err := QueryVolumes(ctx, apiutil.QueryParams{Limit: big})
+	assert.NoError(suite.T(), err)
+	cVol, err := CountVolumes(ctx, apiutil.QueryParams{Limit: big})
+	assertCount("volumes unfiltered", cVol, err, len(allVols))
+
+	qVol := apiutil.QueryParams{Limit: big, Filter: []apiutil.Filter{{Field: "q", Value: []string{"cntmk1"}}}}
+	fVols, err := QueryVolumes(ctx, qVol)
+	assert.NoError(suite.T(), err)
+	cVolF, err := CountVolumes(ctx, qVol)
+	assertCount("volumes q=cntmk1", cVolF, err, len(fVols))
+
+	// Engine entities.
+	seedPub := func(n string) { _, e := AddPublisher(ctx, &vo.PublisherVO{Name: n}); assert.NoError(suite.T(), e) }
+	seedPub("Cntmk2 One")
+	seedPub("Cntmk2 Two")
+	seedPub("Elsewhere")
+	allPub, err := QueryPublishers(ctx, apiutil.QueryParams{Limit: big})
+	assert.NoError(suite.T(), err)
+	cPub, err := CountPublishers(ctx, apiutil.QueryParams{Limit: big})
+	assertCount("publishers unfiltered", cPub, err, len(allPub))
+	fPub, err := QueryPublishers(ctx, apiutil.QueryParams{Limit: big, Filter: regexFilter("name", "cntmk2")})
+	assert.NoError(suite.T(), err)
+	cPubF, err := CountPublishers(ctx, apiutil.QueryParams{Limit: big, Filter: regexFilter("name", "cntmk2")})
+	assertCount("publishers name~cntmk2", cPubF, err, len(fPub))
+
+	seedStu := func(n string) { _, e := AddStudio(ctx, &vo.StudioVO{Name: n}); assert.NoError(suite.T(), e) }
+	seedStu("Cntmk3 One")
+	seedStu("Other Studio")
+	allStu, err := QueryStudios(ctx, apiutil.QueryParams{Limit: big})
+	assert.NoError(suite.T(), err)
+	cStu, err := CountStudios(ctx, apiutil.QueryParams{Limit: big})
+	assertCount("studios unfiltered", cStu, err, len(allStu))
+	fStu, err := QueryStudios(ctx, apiutil.QueryParams{Limit: big, Filter: regexFilter("name", "cntmk3")})
+	assert.NoError(suite.T(), err)
+	cStuF, err := CountStudios(ctx, apiutil.QueryParams{Limit: big, Filter: regexFilter("name", "cntmk3")})
+	assertCount("studios name~cntmk3", cStuF, err, len(fStu))
+
+	seedPer := func(n string) { _, e := AddPerson(ctx, &vo.PersonVO{Name: n}); assert.NoError(suite.T(), e) }
+	seedPer("Cntmk4 One")
+	seedPer("Nobody")
+	allPer, err := QueryPersons(ctx, apiutil.QueryParams{Limit: big})
+	assert.NoError(suite.T(), err)
+	cPer, err := CountPersons(ctx, apiutil.QueryParams{Limit: big})
+	assertCount("persons unfiltered", cPer, err, len(allPer))
+	fPer, err := QueryPersons(ctx, apiutil.QueryParams{Limit: big, Filter: regexFilter("name", "cntmk4")})
+	assert.NoError(suite.T(), err)
+	cPerF, err := CountPersons(ctx, apiutil.QueryParams{Limit: big, Filter: regexFilter("name", "cntmk4")})
+	assertCount("persons name~cntmk4", cPerF, err, len(fPer))
+
+	seedLic := func(t string) { _, e := AddLicense(ctx, &vo.LicenseVO{Title: t}); assert.NoError(suite.T(), e) }
+	seedLic("Cntmk5 One")
+	seedLic("Plain License")
+	allLic, err := QueryLicenses(ctx, apiutil.QueryParams{Limit: big})
+	assert.NoError(suite.T(), err)
+	cLic, err := CountLicenses(ctx, apiutil.QueryParams{Limit: big})
+	assertCount("licenses unfiltered", cLic, err, len(allLic))
+	fLic, err := QueryLicenses(ctx, apiutil.QueryParams{Limit: big, Filter: regexFilter("title", "cntmk5")})
+	assert.NoError(suite.T(), err)
+	cLicF, err := CountLicenses(ctx, apiutil.QueryParams{Limit: big, Filter: regexFilter("title", "cntmk5")})
+	assertCount("licenses title~cntmk5", cLicF, err, len(fLic))
+}
+
 func TestQueryPushdownTestSuite(t *testing.T) {
 	suite.Run(t, new(QueryPushdownTestSuite))
 }

--- a/data/studio_versioning.go
+++ b/data/studio_versioning.go
@@ -199,6 +199,12 @@ func QueryStudios(c context.Context, params apiutil.QueryParams) ([]*vo.StudioVO
 	return vos, nil
 }
 
+// CountStudios returns how many live studios match params' filter, without fetching them -
+// backs catalog-api's list-response meta.total. Same filter as QueryStudios.
+func CountStudios(c context.Context, params apiutil.QueryParams) (int64, error) {
+	return studioVersioning.count(c, params)
+}
+
 // SearchStudios finds live studios whose name contains query (case-insensitive), scanning the
 // full collection - see data.SearchPersons for why this scans in memory rather than pushing the
 // match down to Mongo.

--- a/data/volume.go
+++ b/data/volume.go
@@ -437,6 +437,25 @@ func QueryVolumes(c context.Context, params apiutil.QueryParams) ([]*vo.VolumeVO
 	return vos, nil
 }
 
+// CountVolumes returns how many live volume versions match params' filter - the same `q` $or
+// expansion (title/description/tag values) and any `filter[...][contains]` clauses QueryVolumes
+// applies, plus `state: live` - via a driver CountDocuments. No documents, no sort, no page
+// window. Backs catalog-api's list-response `meta.total`. Like GetCatalogStats it counts on the
+// version collection without joining volume meta, so a volume whose meta is soft-deleted but
+// whose live version still exists is counted (QueryVolumes' per-row meta check would drop it);
+// acceptable for a browse-pager total, matching the stats path's existing behavior.
+func CountVolumes(c context.Context, params apiutil.QueryParams) (int64, error) {
+	span := tracing.BuildSpanWithParams(c, "volumes", "db-count-volumes", params)
+	defer span.End()
+
+	term, rest := extractSearchTerm(params)
+	filter, _, _ := apiutil.ConvertQueryParams(rest)
+	filter = appendSearchOr(filter, term, []string{"title", "description", "tags.value"})
+	filter = append(filter, bson.E{Key: "state", Value: string(models.VersionStateLive)})
+
+	return database.Db.Collection(volumeVersionCollection).CountDocuments(c, filter)
+}
+
 // CatalogStats is a small aggregate over the live volume set - the total count and the most
 // recent submission time - for callers that need a catalog-wide summary (e.g. a landing page)
 // without paginating through every volume themselves.

--- a/data/volume.go
+++ b/data/volume.go
@@ -397,6 +397,7 @@ func QueryVolumes(c context.Context, params apiutil.QueryParams) ([]*vo.VolumeVO
 	filter, sort, projection := apiutil.ConvertQueryParams(params)
 	filter = appendSearchOr(filter, term, []string{"title", "description", "tags.value"})
 	filter = append(filter, bson.E{Key: "state", Value: string(models.VersionStateLive)})
+	sort = normalizeSort(sort)
 	if len(sort) == 0 {
 		// Without an explicit sort, Mongo returns natural (insertion) order - stable for an
 		// untouched record, but an edit re-inserts that record's new live version, so it jumps


### PR DESCRIPTION
Stage **3b.1** of OpenSpec change `catalog-list-handlers-query-pushdown` (sweetrpg/platform#98), added after stage-4 review found v0.33.0 list responses carry no total-count metadata. **No release** in this PR - Handyman 2 sequences it.

## Why

`catalog-web`s browse pager (numbered pages, page window, last-page link) needs the total count of records matching the request filter. Before pushdown it got that from `len()` of the full fetch; after pushdown it only sees one page.

## Change

- `entityVersioningConfig.count(c, params)` - builds the **same filter** as `.query()`: the `q` `$or` expansion over `cfg.searchFields`, any `filter[...][contains]`, plus `state: live` - then `CountDocuments` on the version collection. No document fetch, no sort/page.
- `CountVolumes(c, params)` - the volume equivalent (`q` `$or` over `title`/`description`/`tags.value`).
- `CountPublishers` / `CountStudios` / `CountPersons` / `CountLicenses` wrappers.

Mirrors the existing `.stats()` / `GetCatalogStats` `CountDocuments` pattern. Like those, it counts on the version collection **without joining meta**, so a record whose meta is soft-deleted but whose live version still exists is counted (`.query()`s per-row meta check drops it). Acceptable for a browse-pager total; called out in each doc comment. Switchable to a `$lookup`+`$count` aggregation if exactness matters - flag in review.

## Test

`TestCountMatchesUnpaginatedQueryLength`: `Count<Entity>` == `len` of an unpaginated `Query<Entity>` for the same filter - unfiltered and filtered - for all five entity types. `go build ./... && go vet ./... && go test ./...` green vs MongoDB; `gofmt -l .` clean; `golangci-lint` clean.

## Next

3b.2 (catalog-api): bump to this version, each list handler sets `meta.total` from the matching `Count<Entity>`.

## Note

Commit `a9f6dd4` is unsigned - 1Password signing blocked in this automation env. `develop` has `required_signatures`; needs a re-sign + force-push before merge.