### PR TITLE
Escape the q search term before building its $regex

### DIFF
--- a/data/entity_versioning.go
+++ b/data/entity_versioning.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"reflect"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -65,14 +66,17 @@ func normalizeSort(sortOrder bson.D) bson.D {
 
 // appendSearchOr adds a case-insensitive "contains" $or across fields for a non-empty term.
 // Each clause is the same { $regex, $options: "i" } shape api-core.go's contains operator
-// produces, so a per-field filter[x][contains]=y and a multi-field q stay consistent.
+// produces, so a per-field filter[x][contains]=y and a multi-field q stay consistent - including
+// regexp.QuoteMeta on the term, so it matches literally and a crafted value can't drive
+// catastrophic $regex backtracking on the database.
 func appendSearchOr(filter bson.D, term string, fields []string) bson.D {
 	if term == "" || len(fields) == 0 {
 		return filter
 	}
+	pattern := regexp.QuoteMeta(term)
 	or := make(bson.A, 0, len(fields))
 	for _, f := range fields {
-		or = append(or, bson.D{{Key: f, Value: bson.D{{Key: "$regex", Value: term}, {Key: "$options", Value: "i"}}}})
+		or = append(or, bson.D{{Key: f, Value: bson.D{{Key: "$regex", Value: pattern}, {Key: "$options", Value: "i"}}}})
 	}
 	return append(filter, bson.E{Key: "$or", Value: or})
 }

--- a/data/query_pushdown_test.go
+++ b/data/query_pushdown_test.go
@@ -79,6 +79,30 @@ func (suite *QueryPushdownTestSuite) TestQueryVolumesMultiFieldSearchMatchesDesc
 	// a description-only hit is not missed, which the Contains above proves.
 }
 
+// A `q` term with regex metacharacters is matched literally (QuoteMeta in appendSearchOr), not
+// interpreted as a pattern - so a crafted value can't drive $regex backtracking, and the term
+// finds the record that actually contains that punctuation.
+func (suite *QueryPushdownTestSuite) TestQueryVolumesSearchTermIsLiteralNotRegex() {
+	ctx := suite.T().Context()
+	hit, err := AddVolume(ctx, &vo.VolumeVO{Title: "Manual qp(a+)zz7lit Edition", Description: "x"})
+	assert.NoError(suite.T(), err)
+	_, err = AddVolume(ctx, &vo.VolumeVO{Title: "Manual qpaaaazz7lit Edition", Description: "x"})
+	assert.NoError(suite.T(), err)
+
+	results, err := QueryVolumes(ctx, apiutil.QueryParams{
+		Limit:  200,
+		Filter: []apiutil.Filter{{Field: "q", Value: []string{"qp(a+)zz7lit"}}},
+	})
+	assert.NoError(suite.T(), err)
+
+	var ids []string
+	for _, r := range results {
+		ids = append(ids, r.ID)
+	}
+	assert.Equal(suite.T(), []string{*hit}, ids,
+		"only the literal '(a+)' title matches - not the 'aaaa' one, and no regex error")
+}
+
 // 2.3: name-`contains` filter returns only matching records - one per engine entity type.
 func (suite *QueryPushdownTestSuite) TestQueryPublishersNameContains() {
 	ctx := suite.T().Context()

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.5
 
 require (
 	github.com/stretchr/testify v1.12.1
-	github.com/sweetrpg/api-core.go v0.2.0
+	github.com/sweetrpg/api-core.go v0.3.1
 	github.com/sweetrpg/catalog-objects.go v0.6.0
 	github.com/sweetrpg/common.go v0.0.16
 	github.com/sweetrpg/model-core.go v0.1.0
@@ -22,6 +22,7 @@ require (
 	github.com/go-logr/logr v1.4.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/snappy v1.0.0 // indirect
+	github.com/gomodule/redigo v1.9.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/klauspost/compress v1.18.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/golang/snappy v1.0.0 h1:Oy607GVXHs7RtbggtPBnr2RmDArIsAefDwvrdWvRhGs=
 github.com/golang/snappy v1.0.0/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/gomodule/redigo v1.9.3 h1:dNPSXeXv6HCq2jdyWfjgmhBdqnR6PRO3m/G05nvpPC8=
+github.com/gomodule/redigo v1.9.3/go.mod h1:KsU3hiK/Ay8U42qpaJk+kuNa3C+spxapWpM+ywhcgtw=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
@@ -27,8 +29,8 @@ github.com/montanaflynn/stats v0.7.1 h1:etflOAAHORrCC44V+aR6Ftzort912ZU+YLiSTuV8
 github.com/montanaflynn/stats v0.7.1/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
 github.com/stretchr/testify v1.12.1 h1:EuwCh5fleGS7H32xRwO3wRGT7DxrDhLAT6FF8MpWDWE=
 github.com/stretchr/testify v1.12.1/go.mod h1:MDEgiDPPsNp5cuIrHPPCyornHKgEVbtFUmoNlxoYthg=
-github.com/sweetrpg/api-core.go v0.2.0 h1:iCXJuIxtdQOV8p6JbYOitntbOMmQEpJy7Gh6HkQdF6M=
-github.com/sweetrpg/api-core.go v0.2.0/go.mod h1:L27iRQqlnbAbqymjqGeSIcEJHnBKkL8w5nhq0TVa4Ow=
+github.com/sweetrpg/api-core.go v0.3.1 h1:Fa0dzFjoohTGLt182pO55kksScGNKi6nFHRij/68GTw=
+github.com/sweetrpg/api-core.go v0.3.1/go.mod h1:Li4x24U0q67096dbvOm1Fuq/xOMG1elcgiuJAV8WTJA=
 github.com/sweetrpg/catalog-objects.go v0.6.0 h1:1yWzmcfOrMWF8GC4lYsq6165FNeR4ZYY+bmGlk1xuzc=
 github.com/sweetrpg/catalog-objects.go v0.6.0/go.mod h1:qwB2oluVsq8WSdnZHQTAZ5Z3ZeYrLkimVZPT/jilDs4=
 github.com/sweetrpg/common.go v0.0.16 h1:XT8PwUXz0BOMIITXLjw3G6rEjjRUEs0Xs4+R9o2fVBk=


### PR DESCRIPTION
Security hardening found in review of OpenSpec change `catalog-list-handlers-query-pushdown` (sweetrpg/platform#98).

## Fix

`appendSearchOr` now `regexp.QuoteMeta`-escapes the multi-field `q` term before building the `$regex` clause. `q` is a literal case-insensitive substring search (design intent); an unescaped client value like `filter[q]=(a+)+$` is a server-side ReDoS vector against the shared MongoDB primary. Covers `QueryVolumes`, `CountVolumes`, and `entityVersioningConfig.query`/`count` (all route through `appendSearchOr`).

Pairs with `api-core.go`'s matching fix (sweetrpg/api-core.go#159) for the per-field `filter[x][contains]=` path.

## Follow-up in this PR before merge

Bump `api-core.go` to the #159 release so the `[contains]` operator path is also escaped, then re-run the suite. (Holding until #159 tags.)

## Test

`data/query_pushdown_test.go`: `TestQueryVolumesSearchTermIsLiteralNotRegex` — a `q` of `qp(a+)zz7lit` matches only the volume whose title literally contains `(a+)`, not a `qpaaaa…` one, and doesn't error. Full `go test ./...` green against MongoDB.

Refs sweetrpg/platform#98